### PR TITLE
Correction au niveau du minuteur

### DIFF
--- a/data/minuteur.html
+++ b/data/minuteur.html
@@ -178,7 +178,7 @@
 <script>
   $(document).ready(function() {
     // Récupération des heures de démarrage et d'arrêt depuis le serveur
-    $.get("/getminiteur?relay2", function(data) {
+    $.get("/getminuteur?relay2", function(data) {
       $("#heure_demarrage_relay2").val(data.heure_demarrage);
       $("#heure_arret_relay2").val(data.heure_arret);
       $("#temperature_relay2").val(data.temperature);
@@ -188,13 +188,13 @@
       $("#heure").html( heure + ":" + minute );
     });
 
-    $.get("/getminiteur?relay1", function(data) {
+    $.get("/getminuteur?relay1", function(data) {
       $("#heure_demarrage_relay1").val(data.heure_demarrage);
       $("#heure_arret_relay1").val(data.heure_arret);
       $("#temperature_relay1").val(data.temperature);
     });
 
-    $.get("/getminiteur?dimmer", function(data) {
+    $.get("/getminuteur?dimmer", function(data) {
       $("#heure_demarrage_dimmer").val(data.heure_demarrage);
       $("#heure_arret_dimmer").val(data.heure_arret);
       $("#temperature_dimmer").val(data.temperature);
@@ -208,7 +208,7 @@
       var heure_arret = $("#heure_arret_dimmer").val();
       var temperature = $("#temperature_dimmer").val();
       var puissance = $("#puissance_dimmer").val();
-      $.get("/setminiteur?dimmer", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature, "puissance": puissance});
+      $.get("/setminuteur?dimmer", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature, "puissance": puissance});
     });
 
     $("#relay1-form").submit(function(event) {
@@ -216,7 +216,7 @@
       var heure_demarrage = $("#heure_demarrage_relay1").val();
       var heure_arret = $("#heure_arret_relay1").val();
       var temperature = $("#temperature_relay1").val();
-      $.get("/setminiteur?relay1", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
+      $.get("/setminuteur?relay1", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
     });
 
     $("#relay2-form").submit(function(event) {
@@ -224,7 +224,7 @@
       var heure_demarrage = $("#heure_demarrage_relay2").val();
       var heure_arret = $("#heure_arret_relay2").val();
       var temperature = $("#temperature_relay2").val();
-      $.get("/setminiteur?relay2", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
+      $.get("/setminuteur?relay2", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
     });
 
 
@@ -232,7 +232,7 @@
 
   
   setInterval(function ( ) {
-    $.getJSON('/getminiteur', function(data) {
+    $.getJSON('/getminuteur', function(data) {
         // Affichage de l'heure au format 2 digits
         var heure = data.heure < 10 ? "0" + data.heure : data.heure;
         var minute = data.minute < 10 ? "0" + data.minute : data.minute;

--- a/src/function/web.h
+++ b/src/function/web.h
@@ -284,8 +284,8 @@ void call_pages() {
 
   server.on("/getminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
     if (request->hasParam("dimmer")) { request->send(200, "application/json",  getMinuteur(programme));  }
-    if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
-    if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
+    else if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
+    else if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 

--- a/src/function/web.h
+++ b/src/function/web.h
@@ -317,7 +317,7 @@ void call_pages() {
 
     server.on("/getseuil", HTTP_ANY, [] (AsyncWebServerRequest *request) {
     if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
-    if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
+    else if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 

--- a/src/function/web.h
+++ b/src/function/web.h
@@ -185,14 +185,14 @@ void call_pages() {
         sysvar.change=1; 
         }
         String pb=getState().c_str(); 
-        request->send(200, "text/plain", pb.c_str() );  
+        request->send(200, "application/json", pb.c_str() );
       } 
       
-              else if (request->hasParam(PARAM_INPUT_2)) { 
+      else if (request->hasParam(PARAM_INPUT_2)) {
         config.startingpow = request->getParam(PARAM_INPUT_2)->value().toInt(); 
         logging.Set_log_init("HTTP power at " + String(config.startingpow)+"W\r\n");
         sysvar.change=1; 
-        request->send(200, "text/plain", getState().c_str());
+        request->send(200, "application/json", getState().c_str());
       }
 
       else  { 
@@ -228,18 +228,18 @@ void call_pages() {
     }
     else
     { 
-      request->send(200, "text/plain", textnofiles().c_str());
+      request->send(200, "text/html", textnofiles().c_str());
     }
   });
 
   server.on("/state", HTTP_ANY, [](AsyncWebServerRequest *request){
-    request->send(200, "text/plain", getState().c_str());
+    request->send(200, "application/json", getState().c_str());
   });
 
 
 
     server.on("/state_dallas", HTTP_ANY, [](AsyncWebServerRequest *request){
-    request->send(200, "text/plain", getState_dallas().c_str());
+    request->send(200, "application/json", getState_dallas().c_str());
   });
 
   server.on("/resetwifi", HTTP_ANY, [](AsyncWebServerRequest *request){
@@ -279,7 +279,7 @@ void call_pages() {
   });
 
   server.on("/getmqtt", HTTP_ANY, [] (AsyncWebServerRequest *request) {
-    request->send(200, "text/plain",  getmqtt().c_str()); 
+    request->send(200, "application/json",  getmqtt().c_str());
   });
 
   server.on("/getminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
@@ -341,7 +341,7 @@ void call_pages() {
 
 
   server.on("/config", HTTP_ANY, [](AsyncWebServerRequest *request){
-    request->send(200, "text/plain", getconfig().c_str());
+    request->send(200, "application/json", getconfig().c_str());
   });
 
   server.on("/reset", HTTP_ANY, [](AsyncWebServerRequest *request){

--- a/src/function/web.h
+++ b/src/function/web.h
@@ -282,14 +282,14 @@ void call_pages() {
     request->send(200, "text/plain",  getmqtt().c_str()); 
   });
 
-  server.on("/getminiteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
+  server.on("/getminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
     if (request->hasParam("dimmer")) { request->send(200, "application/json",  getMinuteur(programme));  }
     if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
     if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 
-  server.on("/setminiteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
+  server.on("/setminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
     String name; 
     if (request->hasParam("dimmer")) { 
             if (request->hasParam("heure_demarrage")) { request->getParam("heure_demarrage")->value().toCharArray(programme.heure_demarrage,6);  }


### PR DESCRIPTION
Salut,

Je bosse actuellement sur une intégration avancée dans Home Assistant et se faisant je suis tombé sur quelques petits problèmes au niveau du minuteur :
* Typo `miniteur` vs `minuteur`
* Des doubles réponses HTTP sur certaines routes corrigées en remplaçant quelques `if` par des `elseif`
* Correction du `Content-type` de certaines routes retournant du JSON (`application/json` vs `text/plain`)