### PR TITLE
Nettoyage de code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,15 @@
 # Pre-commit hooks to run tests and ensure code is cleaned.
 # See https://pre-commit.com for more information
 ---
+fail_fast: false
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
         args: ["--print-width", "100"]
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: master
+    hooks:
+      - id: uncrustify
+        args: ["-c", ".uncrustify.cfg", "--replace", "--no-backup"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Pre-commit hooks to run tests and ensure code is cleaned.
+# See https://pre-commit.com for more information
+---
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        args: ["--print-width", "100"]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+*.min.js
+*.min.css
+all.css

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,1 @@
+tabWidth: 2

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,3121 @@
+#
+# Default: auto
+newlines                        = auto     # lf/crlf/cr/auto
+
+# The original size of tabs in the input.
+#
+# Default: 8
+input_tab_size                  = 2        # unsigned number
+
+# The size of tabs in the output (only used if align_with_tabs=true).
+#
+# Default: 8
+output_tab_size                 = 2        # unsigned number
+
+# The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).
+#
+# Default: 92
+string_escape_char              = 92       # unsigned number
+
+# Alternate string escape char (usually only used for Pawn).
+# Only works right before the quote char.
+string_escape_char2             = 0        # unsigned number
+
+# Replace tab characters found in string literals with the escape sequence \t
+# instead.
+string_replace_tab_chars        = false    # true/false
+
+# Allow interpreting '>=' and '>>=' as part of a template in code like
+# 'void f(list<list<B>>=val);'. If true, 'assert(x<0 && y>=3)' will be broken.
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                   = false    # true/false
+
+# Disable formatting of NL_CONT ('\\n') ended lines (e.g. multiline macros)
+disable_processing_nl_cont      = false    # true/false
+
+# Specify the marker used in comments to disable processing of part of the
+# file.
+# The comment should be used alone in one line.
+#
+# Default:  *INDENT-OFF*
+disable_processing_cmt          = " *INDENT-OFF*"      # string
+
+# Specify the marker used in comments to (re)enable processing in a file.
+# The comment should be used alone in one line.
+#
+# Default:  *INDENT-ON*
+enable_processing_cmt           = " *INDENT-ON*"     # string
+
+# Enable parsing of digraphs.
+enable_digraphs                 = false    # true/false
+
+# Add or remove the UTF-8 BOM (recommend 'remove').
+utf8_bom                        = ignore   # ignore/add/remove/force
+
+# If the file contains bytes with values between 128 and 255, but is not
+# UTF-8, then output as UTF-8.
+utf8_byte                       = false    # true/false
+
+# Force the output encoding to UTF-8.
+utf8_force                      = false    # true/false
+
+# Add or remove space between 'do' and '{'.
+sp_do_brace_open                = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'while'.
+sp_brace_close_while            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'while' and '('.
+sp_while_paren_open             = ignore   # ignore/add/remove/force
+
+#
+# Spacing options
+#
+
+# Add or remove space around non-assignment symbolic operators ('+', '/', '%',
+# '<<', and so forth).
+sp_arith                        = ignore   # ignore/add/remove/force
+
+# Add or remove space around arithmetic operators '+' and '-'.
+#
+# Overrides sp_arith.
+sp_arith_additive               = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=', '+=', etc.
+sp_assign                       = ignore   # ignore/add/remove/force
+
+# Add or remove space around '=' in C++11 lambda capture specifications.
+#
+# Overrides sp_assign.
+sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
+
+# Add or remove space after the capture specification of a C++11 lambda when
+# an argument list is present, as in '[] <here> (int x){ ... }'.
+sp_cpp_lambda_square_paren      = ignore   # ignore/add/remove/force
+
+# Add or remove space after the capture specification of a C++11 lambda with
+# no argument list is present, as in '[] <here> { ... }'.
+sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force
+
+# Add or remove space after the argument list of a C++11 lambda, as in
+# '[](int x) <here> { ... }'.
+sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force
+
+# Add or remove space between a lambda body and its call operator of an
+# immediately invoked lambda, as in '[]( ... ){ ... } <here> ( ... )'.
+sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=' in a prototype.
+#
+# If set to ignore, use sp_assign.
+sp_assign_default               = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment operator '=', '+=', etc.
+#
+# Overrides sp_assign.
+sp_before_assign                = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment operator '=', '+=', etc.
+#
+# Overrides sp_assign.
+sp_after_assign                 = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'NS_ENUM ('.
+sp_enum_paren                   = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment '=' in enum.
+sp_enum_assign                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment '=' in enum.
+#
+# Overrides sp_enum_assign.
+sp_enum_before_assign           = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment '=' in enum.
+#
+# Overrides sp_enum_assign.
+sp_enum_after_assign            = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment ':' in enum.
+sp_enum_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space around preprocessor '##' concatenation operator.
+#
+# Default: add
+sp_pp_concat                    = add      # ignore/add/remove/force
+
+# Add or remove space after preprocessor '#' stringify operator.
+# Also affects the '#@' charizing operator.
+sp_pp_stringify                 = ignore   # ignore/add/remove/force
+
+# Add or remove space before preprocessor '#' stringify operator
+# as in '#define x(y) L#y'.
+sp_before_pp_stringify          = ignore   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'.
+sp_bool                         = ignore   # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc.
+sp_compare                      = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'.
+sp_inside_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
+sp_paren_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.
+sp_cparen_oparen                = ignore   # ignore/add/remove/force
+
+# Whether to balance spaces inside nested parentheses.
+sp_balance_nested_parens        = false    # true/false
+
+# Add or remove space between ')' and '{'.
+sp_paren_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between nested braces, i.e. '{{' vs '{ {'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'.
+sp_before_ptr_star              = ignore   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a
+# variable name. If set to ignore, sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
+
+# Add or remove space between pointer stars '*'.
+sp_between_ptr_star             = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+#
+# Overrides sp_type_func.
+sp_after_ptr_star               = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer caret '^', if followed by a word.
+sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a qualifier.
+sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a function
+# prototype or function definition.
+#
+# Overrides sp_after_ptr_star and sp_type_func.
+sp_after_ptr_star_func          = ignore   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open
+# parenthesis, as in 'void* (*)().
+sp_ptr_star_paren               = ignore   # ignore/add/remove/force
+
+# Add or remove space before a pointer star '*', if followed by a function
+# prototype or function definition.
+sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'.
+sp_before_byref                 = ignore   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a
+# variable name. If set to ignore, sp_before_byref is used instead.
+sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+#
+# Overrides sp_type_func.
+sp_after_byref                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a function
+# prototype or function definition.
+#
+# Overrides sp_after_byref and sp_type_func.
+sp_after_byref_func             = ignore   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a function
+# prototype or function definition.
+sp_before_byref_func            = ignore   # ignore/add/remove/force
+
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
+#
+# Default: force
+sp_after_type                   = force    # ignore/add/remove/force
+
+# Add or remove space between 'decltype(...)' and word.
+#
+# Overrides sp_after_type.
+sp_after_decltype               = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space before the parenthesis in the D constructs
+# 'template Foo(' and 'class Foo('.
+sp_before_template_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'template' and '<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle               = ignore   # ignore/add/remove/force
+
+# Add or remove space before '<'.
+sp_before_angle                 = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'.
+sp_inside_angle                 = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '<>'.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and ':'.
+sp_angle_colon                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after '>'.
+sp_after_angle                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and '(' as found in 'new List<byte>(foo);'.
+sp_angle_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and '()' as found in 'new List<byte>();'.
+sp_angle_paren_empty            = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and a word as in 'List<byte> m;' or
+# 'template <typename T> static ...'.
+sp_angle_word                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff).
+#
+# Default: add
+sp_angle_shift                  = add      # ignore/add/remove/force
+
+# (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
+# that sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = false    # true/false
+
+# Add or remove space before '(' of control statements ('if', 'for', 'switch',
+# 'while', etc.).
+sp_before_sparen                = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')' of control statements.
+sp_inside_sparen                = ignore   # ignore/add/remove/force
+
+# Add or remove space after '(' of control statements.
+#
+# Overrides sp_inside_sparen.
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force
+
+# Add or remove space before ')' of control statements.
+#
+# Overrides sp_inside_sparen.
+sp_inside_sparen_close          = ignore   # ignore/add/remove/force
+
+# Add or remove space after ')' of control statements.
+sp_after_sparen                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of of control statements.
+sp_sparen_brace                 = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space between 'invariant' and '('.
+sp_invariant_paren              = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space after the ')' in 'invariant (C) c'.
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+sp_special_semi                 = ignore   # ignore/add/remove/force
+
+# Add or remove space before ';'.
+#
+# Default: remove
+sp_before_semi                  = remove   # ignore/add/remove/force
+
+# Add or remove space before ';' in non-empty 'for' statements.
+sp_before_semi_for              = ignore   # ignore/add/remove/force
+
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty        = ignore   # ignore/add/remove/force
+
+# Add or remove space after ';', except when followed by a comment.
+#
+# Default: add
+sp_after_semi                   = add      # ignore/add/remove/force
+
+# Add or remove space after ';' in non-empty 'for' statements.
+#
+# Default: force
+sp_after_semi_for               = force    # ignore/add/remove/force
+
+# Add or remove space after the final semicolon of an empty part of a for
+# statement, as in 'for ( ; ; <here> )'.
+sp_after_semi_for_empty         = ignore   # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]').
+sp_before_square                = ignore   # ignore/add/remove/force
+
+# Add or remove space before '[' for a variable definition.
+#
+# Default: remove
+sp_before_vardef_square         = remove   # ignore/add/remove/force
+
+# Add or remove space before '[' for asm block.
+sp_before_square_asm_block      = ignore   # ignore/add/remove/force
+
+# Add or remove space before '[]'.
+sp_before_squares               = ignore   # ignore/add/remove/force
+
+# Add or remove space before C++17 structured bindings.
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'.
+sp_inside_square                = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '[]'.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
+# ']'. If set to ignore, sp_inside_square is used.
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force
+
+# Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
+sp_after_comma                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before ','.
+#
+# Default: remove
+sp_before_comma                 = remove   # ignore/add/remove/force
+
+# (C#) Add or remove space between ',' and ']' in multidimensional array type
+# like 'int[,,]'.
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
+
+# (C#) Add or remove space between '[' and ',' in multidimensional array type
+# like 'int[,,]'.
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
+
+# (C#) Add or remove space between ',' in multidimensional array type
+# like 'int[,,]'.
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
+
+# Add or remove space between an open parenthesis and comma,
+# i.e. '(,' vs. '( ,'.
+#
+# Default: force
+sp_paren_comma                  = force    # ignore/add/remove/force
+
+# Add or remove space before the variadic '...' when preceded by a
+# non-punctuator.
+sp_before_ellipsis              = ignore   # ignore/add/remove/force
+
+# Add or remove space between a type and '...'.
+sp_type_ellipsis                = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space between a type and '?'.
+sp_type_question                = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '...'.
+sp_paren_ellipsis               = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and a qualifier such as 'const'.
+sp_paren_qualifier              = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and 'noexcept'.
+sp_paren_noexcept               = ignore   # ignore/add/remove/force
+
+# Add or remove space after class ':'.
+sp_after_class_colon            = ignore   # ignore/add/remove/force
+
+# Add or remove space before class ':'.
+sp_before_class_colon           = ignore   # ignore/add/remove/force
+
+# Add or remove space after class constructor ':'.
+sp_after_constr_colon           = ignore   # ignore/add/remove/force
+
+# Add or remove space before class constructor ':'.
+sp_before_constr_colon          = ignore   # ignore/add/remove/force
+
+# Add or remove space before case ':'.
+#
+# Default: remove
+sp_before_case_colon            = remove   # ignore/add/remove/force
+
+# Add or remove space between 'operator' and operator sign.
+sp_after_operator               = ignore   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open parenthesis, as
+# in 'operator ++('.
+sp_after_operator_sym           = ignore   # ignore/add/remove/force
+
+# Overrides sp_after_operator_sym when the operator has no arguments, as in
+# 'operator *()'.
+sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
+
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or
+# '(int)a' vs. '(int) a'.
+sp_after_cast                   = ignore   # ignore/add/remove/force
+
+# Add or remove spaces inside cast parentheses.
+sp_inside_paren_cast            = ignore   # ignore/add/remove/force
+
+# Add or remove space between the type and open parenthesis in a C++ cast,
+# i.e. 'int(exp)' vs. 'int (exp)'.
+sp_cpp_cast_paren               = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '('.
+sp_sizeof_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '...'.
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof...' and '('.
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'decltype' and '('.
+sp_decltype_paren               = ignore   # ignore/add/remove/force
+
+# (Pawn) Add or remove space after the tag keyword.
+sp_after_tag                    = ignore   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'.
+sp_inside_braces_enum           = ignore   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' and '}'.
+sp_inside_braces_struct         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force
+
+# Add or remove space after open brace in an unnamed temporary
+# direct-list-initialization.
+sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force
+
+# Add or remove space before close brace in an unnamed temporary
+# direct-list-initialization.
+sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force
+
+# Add or remove space inside an unnamed temporary direct-list-initialization.
+sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '{' and '}'.
+sp_inside_braces                = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '{}'.
+sp_inside_braces_empty          = ignore   # ignore/add/remove/force
+
+# Add or remove space around trailing return operator '->'.
+sp_trailing_return              = ignore   # ignore/add/remove/force
+
+# Add or remove space between return type and function name. A minimum of 1
+# is forced except for pointer return types.
+sp_type_func                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between type and open brace of an unnamed temporary
+# direct-list-initialization.
+sp_type_brace_init_lst          = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration.
+sp_func_proto_paren             = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function declaration
+# without parameters.
+sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' with a typedef specifier.
+sp_func_type_paren              = ignore   # ignore/add/remove/force
+
+# Add or remove space between alias name and '(' of a non-pointer function type typedef.
+sp_func_def_paren               = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function definition
+# without parameters.
+sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'.
+# Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
+sp_inside_fparens               = ignore   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'.
+sp_inside_fparen                = ignore   # ignore/add/remove/force
+
+# Add or remove space inside the first parentheses in a function type, as in
+# 'void (*x)(...)'.
+sp_inside_tparen                = ignore   # ignore/add/remove/force
+
+# Add or remove space between the ')' and '(' in a function type, as in
+# 'void (*x)(...)'.
+sp_after_tparen_close           = ignore   # ignore/add/remove/force
+
+# Add or remove space between ']' and '(' when part of a function call.
+sp_square_fparen                = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function.
+sp_fparen_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of a function call in object
+# initialization.
+#
+# Overrides sp_fparen_brace.
+sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force
+
+# (Java) Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls.
+sp_func_call_paren              = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without
+# parameters. If set to ignore (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
+
+# Add or remove space between the user function name and '(' on function
+# calls. You need to set a keyword to be a user function in the config file,
+# like:
+#   set func_call_user tr _ i18n
+sp_func_call_user_paren         = ignore   # ignore/add/remove/force
+
+# Add or remove space inside user function '(' and ')'.
+sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force
+
+# Add or remove space between nested parentheses with user functions,
+# i.e. '((' vs. '( ('.
+sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor/destructor and the open
+# parenthesis.
+sp_func_class_paren             = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor without parameters or destructor
+# and '()'.
+sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '('.
+sp_return_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between '__attribute__' and '('.
+sp_attribute_paren              = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
+sp_defined_paren                = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and '(' in 'throw (something)'.
+sp_throw_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and anything other than '(' as in
+# '@throw [...];'.
+sp_after_throw                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'.
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                  = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between '@catch' and '('
+# in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between class name and '('
+# in '@interface className(categoryName)<ProtocolName>:BaseClass'
+sp_oc_classname_paren           = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space between 'version' and '('
+# in 'version (something) { }'. If set to ignore, sp_before_sparen is used.
+sp_version_paren                = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space between 'scope' and '('
+# in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.
+sp_scope_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'super' and '(' in 'super (something)'.
+#
+# Default: remove
+sp_super_paren                  = remove   # ignore/add/remove/force
+
+# Add or remove space between 'this' and '(' in 'this (something)'.
+#
+# Default: remove
+sp_this_paren                   = remove   # ignore/add/remove/force
+
+# Add or remove space between a macro name and its definition.
+sp_macro                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between a macro function ')' and its definition.
+sp_macro_func                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'else' and '{' if on the same line.
+sp_else_brace                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'else' if on the same line.
+sp_brace_else                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and the name of a typedef on the same line.
+sp_brace_typedef                = ignore   # ignore/add/remove/force
+
+# Add or remove space before the '{' of a 'catch' statement, if the '{' and
+# 'catch' are on the same line, as in 'catch (decl) <here> {'.
+sp_catch_brace                  = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before the '{' of a '@catch' statement, if the '{'
+# and '@catch' are on the same line, as in '@catch (decl) <here> {'.
+# If set to ignore, sp_catch_brace is used.
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'catch' if on the same line.
+sp_brace_catch                  = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between '}' and '@catch' if on the same line.
+# If set to ignore, sp_brace_catch is used.
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'finally' and '{' if on the same line.
+sp_finally_brace                = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'finally' if on the same line.
+sp_brace_finally                = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'try' and '{' if on the same line.
+sp_try_brace                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between get/set and '{' if on the same line.
+sp_getset_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for C++ uniform
+# initialization.
+sp_word_brace_init_lst          = ignore   # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for a namespace.
+#
+# Default: add
+sp_word_brace_ns                = add      # ignore/add/remove/force
+
+# Add or remove space before the '::' operator.
+sp_before_dc                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '::' operator.
+sp_after_dc                     = ignore   # ignore/add/remove/force
+
+# (D) Add or remove around the D named array initializer ':' operator.
+sp_d_array_colon                = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '!' (not) unary operator.
+#
+# Default: remove
+sp_not                          = remove   # ignore/add/remove/force
+
+# Add or remove space after the '~' (invert) unary operator.
+#
+# Default: remove
+sp_inv                          = remove   # ignore/add/remove/force
+
+# Add or remove space after the '&' (address-of) unary operator. This does not
+# affect the spacing after a '&' that is part of a type.
+#
+# Default: remove
+sp_addr                         = remove   # ignore/add/remove/force
+
+# Add or remove space around the '.' or '->' operators.
+#
+# Default: remove
+sp_member                       = remove   # ignore/add/remove/force
+
+# Add or remove space after the '*' (dereference) unary operator. This does
+# not affect the spacing after a '*' that is part of a type.
+#
+# Default: remove
+sp_deref                        = remove   # ignore/add/remove/force
+
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.
+#
+# Default: remove
+sp_sign                         = remove   # ignore/add/remove/force
+
+# Add or remove space between '++' and '--' the word to which it is being
+# applied, as in '(--x)' or 'y++;'.
+#
+# Default: remove
+sp_incdec                       = remove   # ignore/add/remove/force
+
+# Add or remove space before a backslash-newline at the end of a line.
+#
+# Default: add
+sp_before_nl_cont               = add      # ignore/add/remove/force
+
+# (OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'
+# or '+(int) bar;'.
+sp_after_oc_scope               = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after the colon in message specs,
+# i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.
+sp_after_oc_colon               = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before the colon in message specs,
+# i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.
+sp_before_oc_colon              = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after the colon in message specs,
+# i.e. '[object setValue:1];' vs. '[object setValue: 1];'.
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before the colon in message specs,
+# i.e. '[object setValue:1];' vs. '[object setValue :1];'.
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after the (type) in message specs,
+# i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.
+sp_after_oc_type                = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after the first (type) in message specs,
+# i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.
+sp_after_oc_return_type         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between '@selector' and '(',
+# i.e. '@selector(msgName)' vs. '@selector (msgName)'.
+# Also applies to '@protocol()' constructs.
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between '@selector(x)' and the following word,
+# i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space inside '@selector' parentheses,
+# i.e. '@selector(foo)' vs. '@selector( foo )'.
+# Also applies to '@protocol()' constructs.
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space before a block pointer caret,
+# i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after a block pointer caret,
+# i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between the receiver and selector in a message,
+# as in '[receiver selector ...]'.
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space after '@property'.
+sp_after_oc_property            = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove space between '@synchronized' and the open parenthesis,
+# i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force
+
+# Add or remove space around the ':' in 'b ? t : f'.
+sp_cond_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space before the ':' in 'b ? t : f'.
+#
+# Overrides sp_cond_colon.
+sp_cond_colon_before            = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ':' in 'b ? t : f'.
+#
+# Overrides sp_cond_colon.
+sp_cond_colon_after             = ignore   # ignore/add/remove/force
+
+# Add or remove space around the '?' in 'b ? t : f'.
+sp_cond_question                = ignore   # ignore/add/remove/force
+
+# Add or remove space before the '?' in 'b ? t : f'.
+#
+# Overrides sp_cond_question.
+sp_cond_question_before         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '?' in 'b ? t : f'.
+#
+# Overrides sp_cond_question.
+sp_cond_question_after          = ignore   # ignore/add/remove/force
+
+# In the abbreviated ternary form '(a ?: b)', add or remove space between '?'
+# and ':'.
+#
+# Overrides all other sp_cond_* options.
+sp_cond_ternary_short           = ignore   # ignore/add/remove/force
+
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make
+# sense here.
+sp_case_label                   = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space around the D '..' operator.
+sp_range                        = ignore   # ignore/add/remove/force
+
+# Add or remove space after ':' in a Java/C++11 range-based 'for',
+# as in 'for (Type var : expr)'.
+sp_after_for_colon              = ignore   # ignore/add/remove/force
+
+# Add or remove space before ':' in a Java/C++11 range-based 'for',
+# as in 'for (Type var : expr)'.
+sp_before_for_colon             = ignore   # ignore/add/remove/force
+
+# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
+sp_extern_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space after the opening of a C++ comment,
+# i.e. '// A' vs. '//A'.
+sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
+
+# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# sequences like '///', '///<', '//!' and '//!<'.
+sp_cmt_cpp_doxygen              = false    # true/false
+
+# If true, space is added with sp_cmt_cpp_start will be added after Qt
+# translator or meta-data comments like '//:', '//=', and '//~'.
+sp_cmt_cpp_qttr                 = false    # true/false
+
+# Add or remove space between #else or #endif and a trailing comment.
+sp_endif_cmt                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after 'new', 'delete' and 'delete[]'.
+sp_after_new                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'new' and '(' in 'new()'.
+sp_between_new_paren            = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and type in 'new(foo) BAR'.
+sp_after_newop_paren            = ignore   # ignore/add/remove/force
+
+# Add or remove space inside parenthesis of the new operator
+# as in 'new(foo) BAR'.
+sp_inside_newop_paren           = ignore   # ignore/add/remove/force
+
+# Add or remove space after the open parenthesis of the new operator,
+# as in 'new(foo) BAR'.
+#
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
+
+# Add or remove space before the close parenthesis of the new operator,
+# as in 'new(foo) BAR'.
+#
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
+
+# Add or remove space before a trailing or embedded comment.
+sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
+
+# Number of spaces before a trailing or embedded comment.
+sp_num_before_tr_emb_cmt        = 0        # unsigned number
+
+# (Java) Add or remove space between an annotation and the open parenthesis.
+sp_annotation_paren             = ignore   # ignore/add/remove/force
+
+# If true, vbrace tokens are dropped to the previous token and skipped.
+sp_skip_vbrace_tokens           = false    # true/false
+
+# Add or remove space after 'noexcept'.
+sp_after_noexcept               = ignore   # ignore/add/remove/force
+
+# Add or remove space after '_'.
+sp_vala_after_translation       = ignore   # ignore/add/remove/force
+
+# If true, a <TAB> is inserted after #define.
+force_tab_after_define          = false    # true/false
+
+#
+# Indenting options
+#
+
+# The number of columns to indent per level. Usually 2, 3, 4, or 8.
+#
+# Default: 8
+indent_columns                  = 2        # unsigned number
+
+# The continuation indent. If non-zero, this overrides the indent of '(', '['
+# and '=' continuation indents. Negative values are OK; negative value is
+# absolute and not increased for each '(' or '[' level.
+#
+# For FreeBSD, this is set to 4.
+indent_continue                 = 0        # number
+
+# The continuation indent, only for class header line(s). If non-zero, this
+# overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
+
+# Whether to indent empty lines (i.e. lines which contain only spaces before
+# the newline character).
+indent_single_newlines          = false    # true/false
+
+# The continuation indent for func_*_param if they are true. If non-zero, this
+# overrides the indent.
+indent_param                    = 0        # unsigned number
+
+# How to use tabs when indenting code.
+#
+# 0: Spaces only
+# 1: Indent with tabs to brace level, align with spaces (default)
+# 2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: 1
+indent_with_tabs                = 0        # unsigned number
+
+# Whether to indent comments that are not at a brace level with tabs on a
+# tabstop. Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs            = false    # true/false
+
+# Whether to indent strings broken by '\' so that they line up.
+indent_align_string             = false    # true/false
+
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=true.
+indent_xml_string               = 0        # unsigned number
+
+# Spaces to indent '{' from level.
+indent_brace                    = 0        # unsigned number
+
+# Whether braces are indented to the body level.
+indent_braces                   = false    # true/false
+
+# Whether to disable indenting function braces if indent_braces=true.
+indent_braces_no_func           = false    # true/false
+
+# Whether to disable indenting class braces if indent_braces=true.
+indent_braces_no_class          = false    # true/false
+
+# Whether to disable indenting struct braces if indent_braces=true.
+indent_braces_no_struct         = false    # true/false
+
+# Whether to indent based on the size of the brace parent,
+# i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+indent_brace_parent             = false    # true/false
+
+# Whether to indent based on the open parenthesis instead of the open brace
+# in '({\n'.
+indent_paren_open_brace         = false    # true/false
+
+# (C#) Whether to indent the brace of a C# delegate by another level.
+indent_cs_delegate_brace        = false    # true/false
+
+# (C#) Whether to indent a C# delegate (to handle delegates with no brace) by
+# another level.
+indent_cs_delegate_body         = false    # true/false
+
+# Whether to indent the body of a 'namespace'.
+indent_namespace                = false    # true/false
+
+# Whether to indent only the first namespace, and not any nested namespaces.
+# Requires indent_namespace=true.
+indent_namespace_single_indent  = false    # true/false
+
+# The number of spaces to indent a namespace block.
+# If set to zero, use the value indent_columns
+indent_namespace_level          = 0        # unsigned number
+
+# If the body of the namespace is longer than this number, it won't be
+# indented. Requires indent_namespace=true. 0 means no limit.
+indent_namespace_limit          = 0        # unsigned number
+
+# Whether the 'extern "C"' body is indented.
+indent_extern                   = false    # true/false
+
+# Whether the 'class' body is indented.
+indent_class                    = false    # true/false
+
+# Whether to indent the stuff after a leading base class colon.
+indent_class_colon              = false    # true/false
+
+# Whether to indent based on a class colon instead of the stuff after the
+# colon. Requires indent_class_colon=true.
+indent_class_on_colon           = false    # true/false
+
+# Whether to indent the stuff after a leading class initializer colon.
+indent_constr_colon             = false    # true/false
+
+# Virtual indent from the ':' for member initializers.
+#
+# Default: 2
+indent_ctor_init_leading        = 2        # unsigned number
+
+# Additional indent for constructor initializer list.
+# Negative values decrease indent down to the first column.
+indent_ctor_init                = 0        # number
+
+# Whether to indent 'if' following 'else' as a new block under the 'else'.
+# If false, 'else\nif' is treated as 'else if' for indenting purposes.
+indent_else_if                  = false    # true/false
+
+# Amount to indent variable declarations after a open brace.
+#
+#  <0: Relative
+# >=0: Absolute
+indent_var_def_blk              = 0        # number
+
+# Whether to indent continued variable declarations instead of aligning.
+indent_var_def_cont             = false    # true/false
+
+# Whether to indent continued shift expressions ('<<' and '>>') instead of
+# aligning. Set align_left_shift=false when enabling this.
+indent_shift                    = false    # true/false
+
+# Whether to force indentation of function definitions to start in column 1.
+indent_func_def_force_col1      = false    # true/false
+
+# Whether to indent continued function call parameters one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_func_call_param          = false    # true/false
+
+# Whether to indent continued function definition parameters one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_func_def_param           = false    # true/false
+
+# for function definitions, only if indent_func_def_param is false
+# Allows to align params when appropriate and indent them when not
+# behave as if it was true if paren position is more than this value
+# if paren position is more than the option value
+indent_func_def_param_paren_pos_threshold = 0        # unsigned number
+
+# Whether to indent continued function call prototype one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_func_proto_param         = false    # true/false
+
+# Whether to indent continued function call declaration one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_func_class_param         = false    # true/false
+
+# Whether to indent continued class variable constructors one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_func_ctor_var_param      = false    # true/false
+
+# Whether to indent continued template parameter list one indent level,
+# rather than aligning parameters under the open parenthesis.
+indent_template_param           = false    # true/false
+
+# Double the indent for indent_func_xxx_param options.
+# Use both values of the options indent_columns and indent_param.
+indent_func_param_double        = false    # true/false
+
+# Indentation column for standalone 'const' qualifier on a function
+# prototype.
+indent_func_const               = 0        # unsigned number
+
+# Indentation column for standalone 'throw' qualifier on a function
+# prototype.
+indent_func_throw               = 0        # unsigned number
+
+# How to indent within a macro followed by a brace on the same line
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+#
+# Default: true
+indent_macro_brace              = true     # true/false
+
+# The number of spaces to indent a continued '->' or '.'.
+# Usually set to 0, 1, or indent_columns.
+indent_member                   = 0        # unsigned number
+
+# Whether lines broken at '.' or '->' should be indented by a single indent.
+# The indent_member option will not be effective if this is set to true.
+indent_member_single            = false    # true/false
+
+# Spaces to indent single line ('//') comments on lines before code.
+indent_sing_line_comments       = 0        # unsigned number
+
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
+
+# Whether to indent trailing single line ('//') comments relative to the code
+# instead of trying to keep the same absolute column.
+indent_relative_single_line_comments = false    # true/false
+
+# Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
+indent_switch_case              = 0        # unsigned number
+
+# indent 'break' with 'case' from 'switch'.
+indent_switch_break_with_case   = false    # true/false
+
+# Whether to indent preprocessor statements inside of switch statements.
+#
+# Default: true
+indent_switch_pp                = true     # true/false
+
+# Spaces to shift the 'case' line, without affecting any other lines.
+# Usually 0.
+indent_case_shift               = 0        # unsigned number
+
+# Spaces to indent '{' from 'case'. By default, the brace will appear under
+# the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
+indent_case_brace               = 0        # number
+
+# Whether to indent comments found in first column.
+indent_col1_comment             = false    # true/false
+
+# Whether to indent multi string literal in first column.
+indent_col1_multi_string_literal = false    # true/false
+
+# How to indent goto labels.
+#
+#  >0: Absolute column where 1 is the leftmost column
+# <=0: Subtract from brace indent
+#
+# Default: 1
+indent_label                    = 1        # number
+
+# How to indent access specifiers that are followed by a
+# colon.
+#
+#  >0: Absolute column where 1 is the leftmost column
+# <=0: Subtract from brace indent
+#
+# Default: 1
+indent_access_spec              = 1        # number
+
+# Whether to indent the code after an access specifier by one level.
+# If true, this option forces 'indent_access_spec=0'.
+indent_access_spec_body         = false    # true/false
+
+# If an open parenthesis is followed by a newline, whether to indent the next
+# line so that it lines up after the open parenthesis (not recommended).
+indent_paren_nl                 = false    # true/false
+
+# How to indent a close parenthesis after a newline.
+#
+# 0: Indent to body level (default)
+# 1: Align under the open parenthesis
+# 2: Indent to the brace level
+indent_paren_close              = 0        # unsigned number
+
+# Whether to indent the open parenthesis of a function definition,
+# if the parenthesis is on its own line.
+indent_paren_after_func_def     = false    # true/false
+
+# Whether to indent the open parenthesis of a function declaration,
+# if the parenthesis is on its own line.
+indent_paren_after_func_decl    = false    # true/false
+
+# Whether to indent the open parenthesis of a function call,
+# if the parenthesis is on its own line.
+indent_paren_after_func_call    = false    # true/false
+
+# Whether to indent a comma when inside a parenthesis.
+# If true, aligns under the open parenthesis.
+indent_comma_paren              = false    # true/false
+
+# Whether to indent a Boolean operator when inside a parenthesis.
+# If true, aligns under the open parenthesis.
+indent_bool_paren               = false    # true/false
+
+# Whether to indent a semicolon when inside a for parenthesis.
+# If true, aligns under the open for parenthesis.
+indent_semicolon_for_paren      = false    # true/false
+
+# Whether to align the first expression to following ones
+# if indent_bool_paren=true.
+indent_first_bool_expr          = false    # true/false
+
+# Whether to align the first expression to following ones
+# if indent_semicolon_for_paren=true.
+indent_first_for_expr           = false    # true/false
+
+# If an open square is followed by a newline, whether to indent the next line
+# so that it lines up after the open square (not recommended).
+indent_square_nl                = false    # true/false
+
+# (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
+indent_preserve_sql             = false    # true/false
+
+# Whether to align continued statements at the '='. If false or if the '=' is
+# followed by a newline, the next line is indent one tab.
+#
+# Default: true
+indent_align_assign             = true     # true/false
+
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
+# Whether to align continued statements at the '('. If false or the '(' is
+# followed by a newline, the next line indent is one tab.
+#
+# Default: true
+indent_align_paren              = true     # true/false
+
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
+# (OC) Whether to indent Objective-C blocks at brace level instead of usual
+# rules.
+indent_oc_block                 = false    # true/false
+
+# (OC) Indent for Objective-C blocks in a message relative to the parameter
+# name.
+#
+# =0: Use indent_oc_block rules
+# >0: Use specified number of spaces to indent
+indent_oc_block_msg             = 0        # unsigned number
+
+# (OC) Minimum indent for subsequent parameters
+indent_oc_msg_colon             = 0        # unsigned number
+
+# (OC) Whether to prioritize aligning with initial colon (and stripping spaces
+# from lines, if necessary).
+#
+# Default: true
+indent_oc_msg_prioritize_first_colon = true     # true/false
+
+# (OC) Whether to indent blocks the way that Xcode does by default
+# (from the keyword if the parameter is on its own line; otherwise, from the
+# previous indentation level). Requires indent_oc_block_msg=true.
+indent_oc_block_msg_xcode_style = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace is, relative to a
+# message keyword. Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_keyword = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace is, relative to a message
+# colon. Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_colon  = false    # true/false
+
+# (OC) Whether to indent blocks from where the block caret is.
+# Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_caret  = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace caret is.
+# Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_brace  = false    # true/false
+
+# When indenting after virtual brace open and newline add further spaces to
+# reach this minimum indent.
+indent_min_vbrace_open          = 0        # unsigned number
+
+# Whether to add further spaces after regular indent to reach next tabstop
+# when indenting after virtual brace open and newline.
+indent_vbrace_open_on_tabstop   = false    # true/false
+
+# How to indent after a brace followed by another token (not a newline).
+# true:  indent all contained lines to match the token
+# false: indent all contained lines to match the brace
+#
+# Default: true
+indent_token_after_brace        = true     # true/false
+
+# Whether to indent the body of a C++11 lambda.
+indent_cpp_lambda_body          = false    # true/false
+
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace (ie:
+#       2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only add
+#        the indent for the return.
+#
+# Default: true
+indent_compound_literal_return  = true     # true/false
+
+# (C#) Whether to indent a 'using' block if no braces are used.
+#
+# Default: true
+indent_using_block              = true     # true/false
+
+# How to indent the continuation of ternary operator.
+#
+# 0: Off (default)
+# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 2: When the `:` is a continuation, indent it under `?`
+indent_ternary_operator         = 0        # unsigned number
+
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
+# If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
+indent_off_after_return_new     = false    # true/false
+
+# If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.
+indent_single_after_return      = false    # true/false
+
+# Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they
+# have their own indentation).
+indent_ignore_asm_block         = false    # true/false
+
+# Don't indent the close parenthesis of a function definition,
+# if the parenthesis is on its own line.
+donot_indent_func_def_close_paren = false    # true/false
+
+#
+# Newline adding and removing options
+#
+
+# Whether to collapse empty blocks between '{' and '}'.
+# If true, overrides nl_inside_empty_func
+nl_collapse_empty_body          = false    # true/false
+
+# Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
+nl_assign_leave_one_liners      = false    # true/false
+
+# Don't split one-line braced statements inside a 'class xx { }' body.
+nl_class_leave_one_liners       = false    # true/false
+
+# Don't split one-line enums, as in 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners        = false    # true/false
+
+# Don't split one-line get or set functions.
+nl_getset_leave_one_liners      = false    # true/false
+
+# (C#) Don't split one-line property get or set functions.
+nl_cs_property_leave_one_liners = false    # true/false
+
+# Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+# might modify nl_func_type_name
+nl_func_leave_one_liners        = false    # true/false
+
+# Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
+nl_cpp_lambda_leave_one_liners  = false    # true/false
+
+# Don't split one-line if/else statements, as in 'if(...) b++;'.
+nl_if_leave_one_liners          = false    # true/false
+
+# Don't split one-line while statements, as in 'while(...) b++;'.
+nl_while_leave_one_liners       = false    # true/false
+
+# Don't split one-line for statements, as in 'for(...) b++;'.
+nl_for_leave_one_liners         = false    # true/false
+
+# (OC) Don't split one-line Objective-C messages.
+nl_oc_msg_leave_one_liner       = false    # true/false
+
+# (OC) Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove newline between Objective-C block signature and '{'.
+nl_oc_block_brace               = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove blank line before '@interface' statement.
+nl_oc_before_interface          = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove blank line before '@implementation' statement.
+nl_oc_before_implementation     = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove blank line before '@end' statement.
+nl_oc_before_end                = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove newline between '@interface' and '{'.
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove newline between '@implementation' and '{'.
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force
+
+# Add or remove newlines at the start of the file.
+nl_start_of_file                = ignore   # ignore/add/remove/force
+
+# The minimum number of newlines at the start of the file (only used if
+# nl_start_of_file is 'add' or 'force').
+nl_start_of_file_min            = 0        # unsigned number
+
+# Add or remove newline at the end of the file.
+nl_end_of_file                  = ignore   # ignore/add/remove/force
+
+# The minimum number of newlines at the end of the file (only used if
+# nl_end_of_file is 'add' or 'force').
+nl_end_of_file_min              = 0        # unsigned number
+
+# Add or remove newline between '=' and '{'.
+nl_assign_brace                 = ignore   # ignore/add/remove/force
+
+# (D) Add or remove newline between '=' and '['.
+nl_assign_square                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '[]' and '{'.
+nl_tsquare_brace                = ignore   # ignore/add/remove/force
+
+# (D) Add or remove newline after '= ['. Will also affect the newline before
+# the ']'.
+nl_after_square_assign          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function call's ')' and '{', as in
+# 'list_for_each(item, &list) { }'.
+nl_fcall_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and '{'.
+nl_enum_brace                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and 'class'.
+nl_enum_class                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class' and the identifier.
+nl_enum_class_identifier        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class' type and ':'.
+nl_enum_identifier_colon        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class identifier :' and type.
+nl_enum_colon_type              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'.
+nl_struct_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'.
+nl_union_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'.
+nl_if_brace                     = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'.
+nl_brace_else                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'else if' and '{'. If set to ignore,
+# nl_if_brace is used instead.
+nl_elseif_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'.
+nl_else_brace                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'.
+nl_else_if                      = ignore   # ignore/add/remove/force
+
+# Add or remove newline before '{' opening brace
+nl_before_opening_brace_func_class_def = ignore   # ignore/add/remove/force
+
+# Add or remove newline before 'if'/'else if' closing parenthesis.
+nl_before_if_closing_paren      = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'.
+nl_brace_finally                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'.
+nl_finally_brace                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'.
+nl_try_brace                    = ignore   # ignore/add/remove/force
+
+# Add or remove newline between get/set and '{'.
+nl_getset_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'.
+nl_for_brace                    = ignore   # ignore/add/remove/force
+
+# Add or remove newline before the '{' of a 'catch' statement, as in
+# 'catch (decl) <here> {'.
+nl_catch_brace                  = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove newline before the '{' of a '@catch' statement, as in
+# '@catch (decl) <here> {'. If set to ignore, nl_catch_brace is used.
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'.
+nl_brace_catch                  = ignore   # ignore/add/remove/force
+
+# (OC) Add or remove newline between '}' and '@catch'. If set to ignore,
+# nl_brace_catch is used.
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ']'.
+nl_brace_square                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ')' in a function invocation.
+nl_brace_fparen                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'while' and '{'.
+nl_while_brace                  = ignore   # ignore/add/remove/force
+
+# (D) Add or remove newline between 'scope (x)' and '{'.
+nl_scope_brace                  = ignore   # ignore/add/remove/force
+
+# (D) Add or remove newline between 'unittest' and '{'.
+nl_unittest_brace               = ignore   # ignore/add/remove/force
+
+# (D) Add or remove newline between 'version (x)' and '{'.
+nl_version_brace                = ignore   # ignore/add/remove/force
+
+# (C#) Add or remove newline between 'using' and '{'.
+nl_using_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between two open or close braces. Due to general
+# newline/brace handling, REMOVE may not work.
+nl_brace_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'.
+nl_do_brace                     = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement.
+nl_brace_while                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'.
+nl_switch_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'synchronized' and '{'.
+nl_synchronized_brace           = ignore   # ignore/add/remove/force
+
+# Add a newline between ')' and '{' if the ')' is on a different line than the
+# if/for/etc.
+#
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and
+# nl_catch_brace.
+nl_multi_line_cond              = false    # true/false
+
+# Add a newline after '(' if an if/for/while/switch condition spans multiple
+# lines
+nl_multi_line_sparen_open       = ignore   # ignore/add/remove/force
+
+# Add a newline before ')' if an if/for/while/switch condition spans multiple
+# lines. Overrides nl_before_if_closing_paren if both are specified.
+nl_multi_line_sparen_close      = ignore   # ignore/add/remove/force
+
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define            = false    # true/false
+
+# Whether to add a newline before 'case', and a blank line before a 'case'
+# statement that follows a ';' or '}'.
+nl_before_case                  = false    # true/false
+
+# Whether to add a newline after a 'case' statement.
+nl_after_case                   = false    # true/false
+
+# Add or remove newline between a case ':' and '{'.
+#
+# Overrides nl_after_case.
+nl_case_colon_brace             = ignore   # ignore/add/remove/force
+
+# Add or remove newline between ')' and 'throw'.
+nl_before_throw                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'namespace' and '{'.
+nl_namespace_brace              = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template class.
+nl_template_class               = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template class declaration.
+#
+# Overrides nl_template_class.
+nl_template_class_decl          = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<>' of a specialized class declaration.
+#
+# Overrides nl_template_class_decl.
+nl_template_class_decl_special  = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template class definition.
+#
+# Overrides nl_template_class.
+nl_template_class_def           = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<>' of a specialized class definition.
+#
+# Overrides nl_template_class_def.
+nl_template_class_def_special   = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template function.
+nl_template_func                = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template function
+# declaration.
+#
+# Overrides nl_template_func.
+nl_template_func_decl           = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<>' of a specialized function
+# declaration.
+#
+# Overrides nl_template_func_decl.
+nl_template_func_decl_special   = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template function
+# definition.
+#
+# Overrides nl_template_func.
+nl_template_func_def            = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<>' of a specialized function
+# definition.
+#
+# Overrides nl_template_func_def.
+nl_template_func_def_special    = ignore   # ignore/add/remove/force
+
+# Add or remove newline after 'template<...>' of a template variable.
+nl_template_var                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'template<...>' and 'using' of a templated
+# type alias.
+nl_template_using               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'.
+nl_class_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline before or after (depending on pos_class_comma,
+# may not be IGNORE) each',' in the base class list.
+nl_class_init_args              = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the constructor member
+# initialization. Related to nl_constr_colon, pos_constr_colon and
+# pos_constr_comma.
+nl_constr_init_args             = ignore   # ignore/add/remove/force
+
+# Add or remove newline before first element, after comma, and after last
+# element, in 'enum'.
+nl_enum_own_lines               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a function
+# definition.
+# might be modified by nl_func_leave_one_liners
+nl_func_type_name               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class
+# definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name
+# is used instead.
+nl_func_type_name_class         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between class specification and '::'
+# in 'void A::f() { }'. Only appears in separate member implementation (does
+# not appear with in-line implementation).
+nl_func_class_scope             = ignore   # ignore/add/remove/force
+
+# Add or remove newline between function scope and name, as in
+# 'void A :: <here> f() { }'.
+nl_func_scope_name              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype.
+nl_func_proto_type_name         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the
+# declaration.
+nl_func_paren                   = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_paren for functions with no parameters.
+nl_func_paren_empty             = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the
+# definition.
+nl_func_def_paren               = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_paren for functions with no parameters.
+nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the
+# call.
+nl_func_call_paren              = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_call_paren for functions with no parameters.
+nl_func_call_paren_empty        = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function declaration.
+nl_func_decl_start              = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function definition.
+nl_func_def_start               = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single       = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single        = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after '(' in a function declaration if '(' and ')'
+# are in different lines. If false, nl_func_decl_start is used instead.
+nl_func_decl_start_multi_line   = false    # true/false
+
+# Whether to add a newline after '(' in a function definition if '(' and ')'
+# are in different lines. If false, nl_func_def_start is used instead.
+nl_func_def_start_multi_line    = false    # true/false
+
+# Add or remove newline after each ',' in a function declaration.
+nl_func_decl_args               = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function definition.
+nl_func_def_args                = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function call.
+nl_func_call_args               = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after each ',' in a function declaration if '('
+# and ')' are in different lines. If false, nl_func_decl_args is used instead.
+nl_func_decl_args_multi_line    = false    # true/false
+
+# Whether to add a newline after each ',' in a function definition if '('
+# and ')' are in different lines. If false, nl_func_def_args is used instead.
+nl_func_def_args_multi_line     = false    # true/false
+
+# Add or remove newline before the ')' in a function declaration.
+nl_func_decl_end                = ignore   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function definition.
+nl_func_def_end                 = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single         = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single          = ignore   # ignore/add/remove/force
+
+# Whether to add a newline before ')' in a function declaration if '(' and ')'
+# are in different lines. If false, nl_func_decl_end is used instead.
+nl_func_decl_end_multi_line     = false    # true/false
+
+# Whether to add a newline before ')' in a function definition if '(' and ')'
+# are in different lines. If false, nl_func_def_end is used instead.
+nl_func_def_end_multi_line      = false    # true/false
+
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function call.
+nl_func_call_empty              = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after '(' in a function call,
+# has preference over nl_func_call_start_multi_line.
+nl_func_call_start              = ignore   # ignore/add/remove/force
+
+# Whether to add a newline before ')' in a function call.
+nl_func_call_end                = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after '(' in a function call if '(' and ')' are in
+# different lines.
+nl_func_call_start_multi_line   = false    # true/false
+
+# Whether to add a newline after each ',' in a function call if '(' and ')'
+# are in different lines.
+nl_func_call_args_multi_line    = false    # true/false
+
+# Whether to add a newline before ')' in a function call if '(' and ')' are in
+# different lines.
+nl_func_call_end_multi_line     = false    # true/false
+
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false    # true/false
+
+# Whether to add a newline after '<' of a template parameter list.
+nl_template_start               = false    # true/false
+
+# Whether to add a newline after each ',' in a template parameter list.
+nl_template_args                = false    # true/false
+
+# Whether to add a newline before '>' of a template parameter list.
+nl_template_end                 = false    # true/false
+
+# (OC) Whether to put each Objective-C message parameter on a separate line.
+# See nl_oc_msg_leave_one_liner.
+nl_oc_msg_args                  = false    # true/false
+
+# Add or remove newline between function signature and '{'.
+nl_fdef_brace                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between function signature and '{',
+# if signature ends with ')'. Overrides nl_fdef_brace.
+nl_fdef_brace_cond              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between C++11 lambda signature and '{'.
+nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'return' and the return expression.
+nl_return_expr                  = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after semicolons, except in 'for' statements.
+nl_after_semicolon              = false    # true/false
+
+# (Java) Add or remove newline between the ')' and '{{' of the double brace
+# initializer.
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after the type in an unnamed temporary
+# direct-list-initialization.
+nl_type_brace_init_lst          = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after the open brace in an unnamed temporary
+# direct-list-initialization.
+nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force
+
+# Whether to add a newline before the close brace in an unnamed temporary
+# direct-list-initialization.
+nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
+
+# Whether to add a newline after '{'. This also adds a newline before the
+# matching '}'.
+nl_after_brace_open             = false    # true/false
+
+# Whether to add a newline between the open brace and a trailing single-line
+# comment. Requires nl_after_brace_open=true.
+nl_after_brace_open_cmt         = false    # true/false
+
+# Whether to add a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open            = false    # true/false
+
+# Whether to add a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty      = false    # true/false
+
+# Whether to add a newline after '}'. Does not apply if followed by a
+# necessary ';'.
+nl_after_brace_close            = false    # true/false
+
+# Whether to add a newline after a virtual brace close,
+# as in 'if (foo) a++; <here> return;'.
+nl_after_vbrace_close           = false    # true/false
+
+# Add or remove newline between the close brace and identifier,
+# as in 'struct { int a; } <here> b;'. Affects enumerations, unions and
+# structures. If set to ignore, uses nl_after_brace_close.
+nl_brace_struct_var             = ignore   # ignore/add/remove/force
+
+# Whether to alter newlines in '#define' macros.
+nl_define_macro                 = false    # true/false
+
+# Whether to alter newlines between consecutive parenthesis closes. The number
+# of closing parentheses in a line will depend on respective open parenthesis
+# lines.
+nl_squeeze_paren_close          = false    # true/false
+
+# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and
+# '#endif'. Does not affect top-level #ifdefs.
+nl_squeeze_ifdef                = false    # true/false
+
+# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+nl_squeeze_ifdef_top_level      = false    # true/false
+
+# Add or remove blank line before 'if'.
+nl_before_if                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'if' statement. Add/Force work only if the
+# next token is not a closing brace.
+nl_after_if                     = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'for'.
+nl_before_for                   = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'for' statement.
+nl_after_for                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'while'.
+nl_before_while                 = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'while' statement.
+nl_after_while                  = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'switch'.
+nl_before_switch                = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'switch' statement.
+nl_after_switch                 = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'synchronized'.
+nl_before_synchronized          = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'synchronized' statement.
+nl_after_synchronized           = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'do'.
+nl_before_do                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'do/while' statement.
+nl_after_do                     = ignore   # ignore/add/remove/force
+
+# Whether to put a blank line before 'return' statements, unless after an open
+# brace.
+nl_before_return                = false    # true/false
+
+# Whether to put a blank line after 'return' statements, unless followed by a
+# close brace.
+nl_after_return                 = false    # true/false
+
+# Whether to put a blank line before a member '.' or '->' operators.
+nl_before_member                = ignore   # ignore/add/remove/force
+
+# (Java) Whether to put a blank line after a member '.' or '->' operators.
+nl_after_member                 = ignore   # ignore/add/remove/force
+
+# Whether to double-space commented-entries in 'struct'/'union'/'enum'.
+nl_ds_struct_enum_cmt           = false    # true/false
+
+# Whether to force a newline before '}' of a 'struct'/'union'/'enum'.
+# (Lower priority than eat_blanks_before_close_brace.)
+nl_ds_struct_enum_close_brace   = false    # true/false
+
+# Add or remove newline before or after (depending on pos_class_colon) a class
+# colon, as in 'class Foo <here> : <or here> public Bar'.
+nl_class_colon                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline around a class constructor colon. The exact position
+# depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.
+nl_constr_colon                 = ignore   # ignore/add/remove/force
+
+# Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'
+# into a single line. If true, prevents other brace newline rules from turning
+# such code into four lines.
+nl_namespace_two_to_one_liner   = false    # true/false
+
+# Whether to remove a newline in simple unbraced if statements, turning them
+# into one-liners, as in 'if(b)\n i++;' => 'if(b) i++;'.
+nl_create_if_one_liner          = false    # true/false
+
+# Whether to remove a newline in simple unbraced for statements, turning them
+# into one-liners, as in 'for (...)\n stmt;' => 'for (...) stmt;'.
+nl_create_for_one_liner         = false    # true/false
+
+# Whether to remove a newline in simple unbraced while statements, turning
+# them into one-liners, as in 'while (expr)\n stmt;' => 'while (expr) stmt;'.
+nl_create_while_one_liner       = false    # true/false
+
+# Whether to collapse a function definition whose body (not counting braces)
+# is only one line so that the entire definition (prototype, braces, body) is
+# a single line.
+nl_create_func_def_one_liner    = false    # true/false
+
+# Whether to collapse a function definition whose body (not counting braces)
+# is only one line so that the entire definition (prototype, braces, body) is
+# a single line.
+nl_create_list_one_liner        = false    # true/false
+
+# Whether to split one-line simple unbraced if statements into two lines by
+# adding a newline, as in 'if(b) <here> i++;'.
+nl_split_if_one_liner           = false    # true/false
+
+# Whether to split one-line simple unbraced for statements into two lines by
+# adding a newline, as in 'for (...) <here> stmt;'.
+nl_split_for_one_liner          = false    # true/false
+
+# Whether to split one-line simple unbraced while statements into two lines by
+# adding a newline, as in 'while (expr) <here> stmt;'.
+nl_split_while_one_liner        = false    # true/false
+
+# Don't add a newline before a cpp-comment in a parameter list of a function
+# call.
+donot_add_nl_before_cpp_comment = false    # true/false
+
+#
+# Blank line options
+#
+
+# The maximum number of consecutive newlines (3 = 2 blank lines).
+nl_max                          = 0        # unsigned number
+
+# The maximum number of consecutive newlines in a function.
+nl_max_blank_in_func            = 0        # unsigned number
+
+# The number of newlines inside an empty function body.
+# This option is overridden by nl_collapse_empty_body=true
+nl_inside_empty_func            = 0        # unsigned number
+
+# The number of newlines before a function prototype.
+nl_before_func_body_proto       = 0        # unsigned number
+
+# The number of newlines before a multi-line function definition.
+nl_before_func_body_def         = 0        # unsigned number
+
+# The number of newlines before a class constructor/destructor prototype.
+nl_before_func_class_proto      = 0        # unsigned number
+
+# The number of newlines before a class constructor/destructor definition.
+nl_before_func_class_def        = 0        # unsigned number
+
+# The number of newlines after a function prototype.
+nl_after_func_proto             = 0        # unsigned number
+
+# The number of newlines after a function prototype, if not followed by
+# another function prototype.
+nl_after_func_proto_group       = 0        # unsigned number
+
+# The number of newlines after a class constructor/destructor prototype.
+nl_after_func_class_proto       = 0        # unsigned number
+
+# The number of newlines after a class constructor/destructor prototype,
+# if not followed by another constructor/destructor prototype.
+nl_after_func_class_proto_group = 0        # unsigned number
+
+# Whether one-line method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+#
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # true/false
+
+# The number of newlines after '}' of a multi-line function body.
+nl_after_func_body              = 0        # unsigned number
+
+# The number of newlines after '}' of a multi-line function body in a class
+# declaration. Also affects class constructors/destructors.
+#
+# Overrides nl_after_func_body.
+nl_after_func_body_class        = 0        # unsigned number
+
+# The number of newlines after '}' of a single line function body. Also
+# affects class constructors/destructors.
+#
+# Overrides nl_after_func_body and nl_after_func_body_class.
+nl_after_func_body_one_liner    = 0        # unsigned number
+
+# The number of blank lines after a block of variable definitions at the top
+# of a function body.
+#
+# 0: No change (default).
+nl_func_var_def_blk             = 0        # unsigned number
+
+# The number of newlines before a block of typedefs. If nl_after_access_spec
+# is non-zero, that option takes precedence.
+#
+# 0: No change (default).
+nl_typedef_blk_start            = 0        # unsigned number
+
+# The number of newlines after a block of typedefs.
+#
+# 0: No change (default).
+nl_typedef_blk_end              = 0        # unsigned number
+
+# The maximum number of consecutive newlines within a block of typedefs.
+#
+# 0: No change (default).
+nl_typedef_blk_in               = 0        # unsigned number
+
+# The number of newlines before a block of variable definitions not at the top
+# of a function body. If nl_after_access_spec is non-zero, that option takes
+# precedence.
+#
+# 0: No change (default).
+nl_var_def_blk_start            = 0        # unsigned number
+
+# The number of newlines after a block of variable definitions not at the top
+# of a function body.
+#
+# 0: No change (default).
+nl_var_def_blk_end              = 0        # unsigned number
+
+# The maximum number of consecutive newlines within a block of variable
+# definitions.
+#
+# 0: No change (default).
+nl_var_def_blk_in               = 0        # unsigned number
+
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+nl_before_block_comment         = 0        # unsigned number
+
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment             = 0        # unsigned number
+
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment           = 0        # unsigned number
+
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment      = false    # true/false
+
+# Whether to force a newline after a label's colon.
+nl_after_label_colon            = false    # true/false
+
+# The number of newlines after '}' or ';' of a struct/enum/union definition.
+nl_after_struct                 = 0        # unsigned number
+
+# The number of newlines before a class definition.
+nl_before_class                 = 0        # unsigned number
+
+# The number of newlines after '}' or ';' of a class definition.
+nl_after_class                  = 0        # unsigned number
+
+# The number of newlines before a namespace.
+nl_before_namespace             = 0        # unsigned number
+
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+#
+# 0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+#
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
+# The number of newlines after '}' of a namespace.
+nl_after_namespace              = 0        # unsigned number
+
+# The number of newlines before an access specifier label. This also includes
+# the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
+# if after a brace open.
+#
+# 0: No change (default).
+nl_before_access_spec           = 0        # unsigned number
+
+# The number of newlines after an access specifier label. This also includes
+# the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
+# if after a brace open.
+#
+# 0: No change (default).
+#
+# Overrides nl_typedef_blk_start and nl_var_def_blk_start.
+nl_after_access_spec            = 0        # unsigned number
+
+# The number of newlines between a function definition and the function
+# comment, as in '// comment\n <here> void foo() {...}'.
+#
+# 0: No change (default).
+nl_comment_func_def             = 0        # unsigned number
+
+# The number of newlines after a try-catch-finally block that isn't followed
+# by a brace close.
+#
+# 0: No change (default).
+nl_after_try_catch_finally      = 0        # unsigned number
+
+# (C#) The number of newlines before and after a property, indexer or event
+# declaration.
+#
+# 0: No change (default).
+nl_around_cs_property           = 0        # unsigned number
+
+# (C#) The number of newlines between the get/set/add/remove handlers.
+#
+# 0: No change (default).
+nl_between_get_set              = 0        # unsigned number
+
+# (C#) Add or remove newline between property and the '{'.
+nl_property_brace               = ignore   # ignore/add/remove/force
+
+# Whether to remove blank lines after '{'.
+eat_blanks_after_open_brace     = false    # true/false
+
+# Whether to remove blank lines before '}'.
+eat_blanks_before_close_brace   = false    # true/false
+
+# How aggressively to remove extra newlines not in preprocessor.
+#
+# 0: No change (default)
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines        = 0        # unsigned number
+
+# (Java) Add or remove newline after an annotation statement. Only affects
+# annotations that are after a newline.
+nl_after_annotation             = ignore   # ignore/add/remove/force
+
+# (Java) Add or remove newline between two annotations.
+nl_between_annotation           = ignore   # ignore/add/remove/force
+
+# The number of newlines before a whole-file #ifdef.
+#
+# 0: No change (default).
+nl_before_whole_file_ifdef      = 0        # unsigned number
+
+# The number of newlines after a whole-file #ifdef.
+#
+# 0: No change (default).
+nl_after_whole_file_ifdef       = 0        # unsigned number
+
+# The number of newlines before a whole-file #endif.
+#
+# 0: No change (default).
+nl_before_whole_file_endif      = 0        # unsigned number
+
+# The number of newlines after a whole-file #endif.
+#
+# 0: No change (default).
+nl_after_whole_file_endif       = 0        # unsigned number
+
+#
+# Positioning options
+#
+
+# The position of arithmetic operators in wrapped expressions.
+pos_arith                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of assignment in wrapped expressions. Do not affect '='
+# followed by '{'.
+pos_assign                      = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of Boolean operators in wrapped expressions.
+pos_bool                        = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of comparison operators in wrapped expressions.
+pos_compare                     = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of conditional operators, as in the '?' and ':' of
+# 'expr ? stmt : stmt', in wrapped expressions.
+pos_conditional                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in wrapped expressions.
+pos_comma                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in enum entries.
+pos_enum_comma                  = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in the base class list if there is more than one
+# line. Affects nl_class_init_args.
+pos_class_comma                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in the constructor initialization list.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
+pos_constr_comma                = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of trailing/leading class colon, between class and base class
+# list. Affects nl_class_colon.
+pos_class_colon                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of colons between constructor and member initialization.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
+pos_constr_colon                = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of shift operators in wrapped expressions.
+pos_shift                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+#
+# Line splitting options
+#
+
+# Try to limit code width to N columns.
+code_width                      = 120        # unsigned number
+
+# Whether to fully split long 'for' statements at semi-colons.
+ls_for_split_full               = false    # true/false
+
+# Whether to fully split long function prototypes/calls at commas.
+# The option ls_code_width has priority over the option ls_func_split_full.
+ls_func_split_full              = false    # true/false
+
+# Whether to split lines as close to code_width as possible and ignore some
+# groupings.
+# The option ls_code_width has priority over the option ls_func_split_full.
+ls_code_width                   = false    # true/false
+
+#
+# Code alignment options (not left column spaces/tabs)
+#
+
+# Whether to keep non-indenting tabs.
+align_keep_tabs                 = false    # true/false
+
+# Whether to use tabs for aligning.
+align_with_tabs                 = false    # true/false
+
+# Whether to bump out to the next tab when aligning.
+align_on_tabstop                = false    # true/false
+
+# Whether to right-align numbers.
+align_number_right              = false    # true/false
+
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space          = false    # true/false
+
+# Whether to align variable definitions in prototypes and functions.
+align_func_params               = false    # true/false
+
+# The span for aligning parameter definitions in function on parameter name.
+#
+# 0: Don't align (default).
+align_func_params_span          = 0        # unsigned number
+
+# The threshold for aligning function parameter definitions.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_func_params_thresh        = 0        # number
+
+# The gap for aligning function parameter definitions.
+align_func_params_gap           = 0        # unsigned number
+
+# The span for aligning constructor value.
+#
+# 0: Don't align (default).
+align_constr_value_span         = 0        # unsigned number
+
+# The threshold for aligning constructor value.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_constr_value_thresh       = 0        # number
+
+# The gap for aligning constructor value.
+align_constr_value_gap          = 0        # unsigned number
+
+# Whether to align parameters in single-line functions that have the same
+# name. The function names must already be aligned with each other.
+align_same_func_call_params     = false    # true/false
+
+# The span for aligning function-call parameters for single line functions.
+#
+# 0: Don't align (default).
+align_same_func_call_params_span = 0        # unsigned number
+
+# The threshold for aligning function-call parameters for single line
+# functions.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_same_func_call_params_thresh = 0        # number
+
+# The span for aligning variable definitions.
+#
+# 0: Don't align (default).
+align_var_def_span              = 0        # unsigned number
+
+# How to consider (or treat) the '*' in the alignment of variable definitions.
+#
+# 0: Part of the type     'void *   foo;' (default)
+# 1: Part of the variable 'void     *foo;'
+# 2: Dangling             'void    *foo;'
+# Dangling: the '*' will not be taken into account when aligning.
+align_var_def_star_style        = 0        # unsigned number
+
+# How to consider (or treat) the '&' in the alignment of variable definitions.
+#
+# 0: Part of the type     'long &   foo;' (default)
+# 1: Part of the variable 'long     &foo;'
+# 2: Dangling             'long    &foo;'
+# Dangling: the '&' will not be taken into account when aligning.
+align_var_def_amp_style         = 0        # unsigned number
+
+# The threshold for aligning variable definitions.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_var_def_thresh            = 0        # number
+
+# The gap for aligning variable definitions.
+align_var_def_gap               = 0        # unsigned number
+
+# Whether to align the colon in struct bit fields.
+align_var_def_colon             = false    # true/false
+
+# The gap for aligning the colon in struct bit fields.
+align_var_def_colon_gap         = 0        # unsigned number
+
+# Whether to align any attribute after the variable name.
+align_var_def_attribute         = false    # true/false
+
+# Whether to align inline struct/enum/union variable definitions.
+align_var_def_inline            = false    # true/false
+
+# The span for aligning on '=' in assignments.
+#
+# 0: Don't align (default).
+align_assign_span               = 0        # unsigned number
+
+# The span for aligning on '=' in function prototype modifier.
+#
+# 0: Don't align (default).
+align_assign_func_proto_span    = 0        # unsigned number
+
+# The threshold for aligning on '=' in assignments.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_assign_thresh             = 0        # number
+
+# How to apply align_assign_span to function declaration "assignments", i.e.
+# 'virtual void foo() = 0' or '~foo() = {default|delete}'.
+#
+# 0: Align with other assignments (default)
+# 1: Align with each other, ignoring regular assignments
+# 2: Don't align
+align_assign_decl_func          = 0        # unsigned number
+
+# The span for aligning on '=' in enums.
+#
+# 0: Don't align (default).
+align_enum_equ_span             = 0        # unsigned number
+
+# The threshold for aligning on '=' in enums.
+# Use a negative number for absolute thresholds.
+#
+# 0: no limit (default).
+align_enum_equ_thresh           = 0        # number
+
+# The span for aligning class member definitions.
+#
+# 0: Don't align (default).
+align_var_class_span            = 0        # unsigned number
+
+# The threshold for aligning class member definitions.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_var_class_thresh          = 0        # number
+
+# The gap for aligning class member definitions.
+align_var_class_gap             = 0        # unsigned number
+
+# The span for aligning struct/union member definitions.
+#
+# 0: Don't align (default).
+align_var_struct_span           = 0        # unsigned number
+
+# The threshold for aligning struct/union member definitions.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_var_struct_thresh         = 0        # number
+
+# The gap for aligning struct/union member definitions.
+align_var_struct_gap            = 0        # unsigned number
+
+# The span for aligning struct initializer values.
+#
+# 0: Don't align (default).
+align_struct_init_span          = 0        # unsigned number
+
+# The span for aligning single-line typedefs.
+#
+# 0: Don't align (default).
+align_typedef_span              = 0        # unsigned number
+
+# The minimum space between the type and the synonym of a typedef.
+align_typedef_gap               = 0        # unsigned number
+
+# How to align typedef'd functions with other typedefs.
+#
+# 0: Don't mix them at all (default)
+# 1: Align the open parenthesis with the types
+# 2: Align the function type name with the other type names
+align_typedef_func              = 0        # unsigned number
+
+# How to consider (or treat) the '*' in the alignment of typedefs.
+#
+# 0: Part of the typedef type, 'typedef int * pint;' (default)
+# 1: Part of type name:        'typedef int   *pint;'
+# 2: Dangling:                 'typedef int  *pint;'
+# Dangling: the '*' will not be taken into account when aligning.
+align_typedef_star_style        = 0        # unsigned number
+
+# How to consider (or treat) the '&' in the alignment of typedefs.
+#
+# 0: Part of the typedef type, 'typedef int & intref;' (default)
+# 1: Part of type name:        'typedef int   &intref;'
+# 2: Dangling:                 'typedef int  &intref;'
+# Dangling: the '&' will not be taken into account when aligning.
+align_typedef_amp_style         = 0        # unsigned number
+
+# The span for aligning comments that end lines.
+#
+# 0: Don't align (default).
+align_right_cmt_span            = 0        # unsigned number
+
+# Minimum number of columns between preceding text and a trailing comment in
+# order for the comment to qualify for being aligned. Must be non-zero to have
+# an effect.
+align_right_cmt_gap             = 0        # unsigned number
+
+# If aligning comments, whether to mix with comments after '}' and #endif with
+# less than three spaces before the comment.
+align_right_cmt_mix             = false    # true/false
+
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # true/false
+
+# Minimum column at which to align trailing comments. Comments which are
+# aligned beyond this column, but which can be aligned in a lesser column,
+# may be "pulled in".
+#
+# 0: Ignore (default).
+align_right_cmt_at_col          = 0        # unsigned number
+
+# The span for aligning function prototypes.
+#
+# 0: Don't align (default).
+align_func_proto_span           = 0        # unsigned number
+
+# The threshold for aligning function prototypes.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_func_proto_thresh         = 0        # number
+
+# Minimum gap between the return type and the function name.
+align_func_proto_gap            = 0        # unsigned number
+
+# Whether to align function prototypes on the 'operator' keyword instead of
+# what follows.
+align_on_operator               = false    # true/false
+
+# Whether to mix aligning prototype and variable declarations. If true,
+# align_var_def_XXX options are used instead of align_func_proto_XXX options.
+align_mix_var_proto             = false    # true/false
+
+# Whether to align single-line functions with function prototypes.
+# Uses align_func_proto_span.
+align_single_line_func          = false    # true/false
+
+# Whether to align the open brace of single-line functions.
+# Requires align_single_line_func=true. Uses align_func_proto_span.
+align_single_line_brace         = false    # true/false
+
+# Gap for align_single_line_brace.
+align_single_line_brace_gap     = 0        # unsigned number
+
+# (OC) The span for aligning Objective-C message specifications.
+#
+# 0: Don't align (default).
+align_oc_msg_spec_span          = 0        # unsigned number
+
+# Whether to align macros wrapped with a backslash and a newline. This will
+# not work right if the macro contains a multi-line comment.
+align_nl_cont                   = false    # true/false
+
+# Whether to align macro functions and variables together.
+align_pp_define_together        = false    # true/false
+
+# The span for aligning on '#define' bodies.
+#
+# =0: Don't align (default)
+# >0: Number of lines (including comments) between blocks
+align_pp_define_span            = 0        # unsigned number
+
+# The minimum space between label and value of a preprocessor define.
+align_pp_define_gap             = 0        # unsigned number
+
+# Whether to align lines that start with '<<' with previous '<<'.
+#
+# Default: true
+align_left_shift                = true     # true/false
+
+# Whether to align comma-separated statements following '<<' (as used to
+# initialize Eigen matrices).
+align_eigen_comma_init          = false    # true/false
+
+# Whether to align text after 'asm volatile ()' colons.
+align_asm_colon                 = false    # true/false
+
+# (OC) Span for aligning parameters in an Objective-C message call
+# on the ':'.
+#
+# 0: Don't align.
+align_oc_msg_colon_span         = 0        # unsigned number
+
+# (OC) Whether to always align with the first parameter, even if it is too
+# short.
+align_oc_msg_colon_first        = false    # true/false
+
+# (OC) Whether to align parameters in an Objective-C '+' or '-' declaration
+# on the ':'.
+align_oc_decl_colon             = false    # true/false
+
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# aligment)
+align_oc_msg_colon_xcode_like   = false    # true/false
+
+#
+# Comment modification options
+#
+
+# Try to wrap comments at N columns.
+cmt_width                       = 0        # unsigned number
+
+# How to reflow comments.
+#
+# 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
+# 1: No touching at all
+# 2: Full reflow
+cmt_reflow_mode                 = 0        # unsigned number
+
+# Whether to convert all tabs to spaces in comments. If false, tabs in
+# comments are left alone, unless used for indenting.
+cmt_convert_tab_to_spaces       = true    # true/false
+
+# Whether to apply changes to multi-line comments, including cmt_width,
+# keyword substitution and leading chars.
+#
+# Default: true
+cmt_indent_multi                = true     # true/false
+
+# Whether to group c-comments that look like they are in a block.
+cmt_c_group                     = false    # true/false
+
+# Whether to put an empty '/*' on the first line of the combined c-comment.
+cmt_c_nl_start                  = false    # true/false
+
+# Whether to add a newline before the closing '*/' of the combined c-comment.
+cmt_c_nl_end                    = false    # true/false
+
+# Whether to change cpp-comments into c-comments.
+cmt_cpp_to_c                    = false    # true/false
+
+# Whether to group cpp-comments that look like they are in a block. Only
+# meaningful if cmt_cpp_to_c=true.
+cmt_cpp_group                   = false    # true/false
+
+# Whether to put an empty '/*' on the first line of the combined cpp-comment
+# when converting to a c-comment.
+#
+# Requires cmt_cpp_to_c=true and cmt_cpp_group=true.
+cmt_cpp_nl_start                = false    # true/false
+
+# Whether to add a newline before the closing '*/' of the combined cpp-comment
+# when converting to a c-comment.
+#
+# Requires cmt_cpp_to_c=true and cmt_cpp_group=true.
+cmt_cpp_nl_end                  = false    # true/false
+
+# Whether to put a star on subsequent comment lines.
+cmt_star_cont                   = false    # true/false
+
+# The number of spaces to insert at the start of subsequent comment lines.
+cmt_sp_before_star_cont         = 0        # unsigned number
+
+# The number of spaces to insert after the star on subsequent comment lines.
+cmt_sp_after_star_cont          = 0        # unsigned number
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first
+# and last lines of the comment are the same length.
+#
+# Default: true
+cmt_multi_check_last            = true     # true/false
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first
+# and last lines of the comment are the same length AND if the length is
+# bigger as the first_len minimum.
+#
+# Default: 4
+cmt_multi_first_len_minimum     = 4        # unsigned number
+
+# Path to a file that contains text to insert at the beginning of a file if
+# the file doesn't start with a C/C++ comment. If the inserted text contains
+# '$(filename)', that will be replaced with the current file's name.
+cmt_insert_file_header          = ""         # string
+
+# Path to a file that contains text to insert at the end of a file if the
+# file doesn't end with a C/C++ comment. If the inserted text contains
+# '$(filename)', that will be replaced with the current file's name.
+cmt_insert_file_footer          = ""         # string
+
+# Path to a file that contains text to insert before a function definition if
+# the function isn't preceded by a C/C++ comment. If the inserted text
+# contains '$(function)', '$(javaparam)' or '$(fclass)', these will be
+# replaced with, respectively, the name of the function, the javadoc '@param'
+# and '@return' stuff, or the name of the class to which the member function
+# belongs.
+cmt_insert_func_header          = ""         # string
+
+# Path to a file that contains text to insert before a class if the class
+# isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',
+# that will be replaced with the class name.
+cmt_insert_class_header         = ""         # string
+
+# Path to a file that contains text to insert before an Objective-C message
+# specification, if the method isn't preceded by a C/C++ comment. If the
+# inserted text contains '$(message)' or '$(javaparam)', these will be
+# replaced with, respectively, the name of the function, or the javadoc
+# '@param' and '@return' stuff.
+cmt_insert_oc_msg_header        = ""         # string
+
+# Whether a comment should be inserted if a preprocessor is encountered when
+# stepping backwards from a function name.
+#
+# Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and
+# cmt_insert_class_header.
+cmt_insert_before_preproc       = false    # true/false
+
+# Whether a comment should be inserted if a function is declared inline to a
+# class definition.
+#
+# Applies to cmt_insert_func_header.
+#
+# Default: true
+cmt_insert_before_inlines       = true     # true/false
+
+# Whether a comment should be inserted if the function is a class constructor
+# or destructor.
+#
+# Applies to cmt_insert_func_header.
+cmt_insert_before_ctor_dtor     = false    # true/false
+
+#
+# Code modifying options (non-whitespace)
+#
+
+# Add or remove braces on a single-line 'do' statement.
+mod_full_brace_do               = ignore   # ignore/add/remove/force
+
+# Add or remove braces on a single-line 'for' statement.
+mod_full_brace_for              = ignore   # ignore/add/remove/force
+
+# (Pawn) Add or remove braces on a single-line function definition.
+mod_full_brace_function         = ignore   # ignore/add/remove/force
+
+# Add or remove braces on a single-line 'if' statement. Braces will not be
+# removed if the braced statement contains an 'else'.
+mod_full_brace_if               = ignore   # ignore/add/remove/force
+
+# Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either
+# have, or do not have, braces. If true, braces will be added if any block
+# needs braces, and will only be removed if they can be removed from all
+# blocks.
+#
+# Overrides mod_full_brace_if.
+mod_full_brace_if_chain         = false    # true/false
+
+# Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.
+# If true, mod_full_brace_if_chain will only remove braces from an 'if' that
+# does not have an 'else if' or 'else'.
+mod_full_brace_if_chain_only    = false    # true/false
+
+# Add or remove braces on single-line 'while' statement.
+mod_full_brace_while            = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'using ()' statement.
+mod_full_brace_using            = ignore   # ignore/add/remove/force
+
+# Don't remove braces around statements that span N newlines
+mod_full_brace_nl               = 0        # unsigned number
+
+# Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks
+# which span multiple lines.
+#
+# Affects:
+#   mod_full_brace_for
+#   mod_full_brace_if
+#   mod_full_brace_if_chain
+#   mod_full_brace_if_chain_only
+#   mod_full_brace_while
+#   mod_full_brace_using
+#
+# Does not affect:
+#   mod_full_brace_do
+#   mod_full_brace_function
+mod_full_brace_nl_block_rem_mlcond = false    # true/false
+
+# Add or remove unnecessary parenthesis on 'return' statement.
+mod_paren_on_return             = ignore   # ignore/add/remove/force
+
+# (Pawn) Whether to change optional semicolons to real semicolons.
+mod_pawn_semicolon              = false    # true/false
+
+# Whether to fully parenthesize Boolean expressions in 'while' and 'if'
+# statement, as in 'if (a && b > c)' => 'if (a && (b > c))'.
+mod_full_paren_if_bool          = false    # true/false
+
+# Whether to remove superfluous semicolons.
+mod_remove_extra_semicolon      = false    # true/false
+
+# If a function body exceeds the specified number of newlines and doesn't have
+# a comment after the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment = 0        # unsigned number
+
+# If a namespace body exceeds the specified number of newlines and doesn't
+# have a comment after the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 0        # unsigned number
+
+# If a class body exceeds the specified number of newlines and doesn't have a
+# comment after the close brace, a comment will be added.
+mod_add_long_class_closebrace_comment = 0        # unsigned number
+
+# If a switch body exceeds the specified number of newlines and doesn't have a
+# comment after the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment = 0        # unsigned number
+
+# If an #ifdef body exceeds the specified number of newlines and doesn't have
+# a comment after the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment = 0        # unsigned number
+
+# If an #ifdef or #else body exceeds the specified number of newlines and
+# doesn't have a comment after the #else, a comment will be added.
+mod_add_long_ifdef_else_comment = 0        # unsigned number
+
+# Whether to take care of the case by the mod_sort_xx options.
+mod_sort_case_sensitive         = false    # true/false
+
+# Whether to sort consecutive single-line 'import' statements.
+mod_sort_import                 = false    # true/false
+
+# (C#) Whether to sort consecutive single-line 'using' statements.
+mod_sort_using                  = false    # true/false
+
+# Whether to sort consecutive single-line '#include' statements (C/C++) and
+# '#import' statements (Objective-C). Be aware that this has the potential to
+# break your code if your includes/imports have ordering dependencies.
+mod_sort_include                = false    # true/false
+
+# Whether to prioritize '#include' and '#import' statements that contain
+# filename without extension when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
+# Whether to prioritize '#include' and '#import' statements that does not
+# contain extensions when sorting is enabled.
+mod_sort_incl_import_prioritize_extensionless = false    # true/false
+
+# Whether to prioritize '#include' and '#import' statements that contain
+# angle over quotes when sorting is enabled.
+mod_sort_incl_import_prioritize_angle_over_quotes = false    # true/false
+
+# Whether to ignore file extension in '#include' and '#import' statements
+# for sorting comparison.
+mod_sort_incl_import_ignore_extension = false    # true/false
+
+# Whether to group '#include' and '#import' statements when sorting is enabled.
+mod_sort_incl_import_grouping_enabled = false    # true/false
+
+# Whether to move a 'break' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
+mod_move_case_break             = false    # true/false
+
+# Add or remove braces around a fully braced case statement. Will only remove
+# braces if there are no variable declarations in the block.
+mod_case_brace                  = ignore   # ignore/add/remove/force
+
+# Whether to remove a void 'return;' that appears as the last statement in a
+# function.
+mod_remove_empty_return         = false    # true/false
+
+# Add or remove the comma after the last value of an enumeration.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
+
+# (OC) Whether to organize the properties. If true, properties will be
+# rearranged according to the mod_sort_oc_property_*_weight factors.
+mod_sort_oc_properties          = false    # true/false
+
+# (OC) Weight of a class property modifier.
+mod_sort_oc_property_class_weight = 0        # number
+
+# (OC) Weight of 'atomic' and 'nonatomic'.
+mod_sort_oc_property_thread_safe_weight = 0        # number
+
+# (OC) Weight of 'readwrite' when organizing properties.
+mod_sort_oc_property_readwrite_weight = 0        # number
+
+# (OC) Weight of a reference type specifier ('retain', 'copy', 'assign',
+# 'weak', 'strong') when organizing properties.
+mod_sort_oc_property_reference_weight = 0        # number
+
+# (OC) Weight of getter type ('getter=') when organizing properties.
+mod_sort_oc_property_getter_weight = 0        # number
+
+# (OC) Weight of setter type ('setter=') when organizing properties.
+mod_sort_oc_property_setter_weight = 0        # number
+
+# (OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',
+# 'null_resettable') when organizing properties.
+mod_sort_oc_property_nullability_weight = 0        # number
+
+#
+# Preprocessor options
+#
+
+# Add or remove indentation of preprocessor directives inside #if blocks
+# at brace level 0 (file-level).
+pp_indent                       = ignore   # ignore/add/remove/force
+
+# Whether to indent #if/#else/#endif at the brace level. If false, these are
+# indented from column 1.
+pp_indent_at_level              = false    # true/false
+
+# Specifies the number of columns to indent preprocessors per level
+# at brace level 0 (file-level). If pp_indent_at_level=false, also specifies
+# the number of columns to indent preprocessors per level
+# at brace level > 0 (function-level).
+#
+# Default: 1
+pp_indent_count                 = 1        # unsigned number
+
+# Add or remove space after # based on pp_level of #if blocks.
+pp_space                        = ignore   # ignore/add/remove/force
+
+# Sets the number of spaces per level added with pp_space.
+pp_space_count                  = 0        # unsigned number
+
+# The indent for '#region' and '#endregion' in C# and '#pragma region' in
+# C/C++. Negative values decrease indent down to the first column.
+pp_indent_region                = 0        # number
+
+# Whether to indent the code between #region and #endregion.
+pp_region_indent_code           = false    # true/false
+
+# If pp_indent_at_level=true, sets the indent for #if, #else and #endif when
+# not at file-level. Negative values decrease indent down to the first column.
+#
+# =0: Indent preprocessors using output_tab_size
+# >0: Column at which all preprocessors will be indented
+pp_indent_if                    = 0        # number
+
+# Whether to indent the code between #if, #else and #endif.
+pp_if_indent_code               = false    # true/false
+
+# Whether to indent '#define' at the brace level. If false, these are
+# indented from column 1.
+pp_define_at_level              = false    # true/false
+
+# Whether to ignore the '#define' body while formatting.
+pp_ignore_define_body           = false    # true/false
+
+# Whether to indent case statements between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the case statements
+# directly inside of.
+#
+# Default: true
+pp_indent_case                  = true     # true/false
+
+# Whether to indent whole function definitions between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the function definition
+# is directly inside of.
+#
+# Default: true
+pp_indent_func_def              = true     # true/false
+
+# Whether to indent extern C blocks between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the extern block is
+# directly inside of.
+#
+# Default: true
+pp_indent_extern                = true     # true/false
+
+# Whether to indent braces directly inside #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the braces are directly
+# inside of.
+#
+# Default: true
+pp_indent_brace                 = true     # true/false
+
+#
+# Sort includes options
+#
+
+# The regex for include category with priority 0.
+include_category_0              = ""         # string
+
+# The regex for include category with priority 1.
+include_category_1              = ""         # string
+
+# The regex for include category with priority 2.
+include_category_2              = ""         # string
+
+#
+# Use or Do not Use options
+#
+
+# true:  indent_func_call_param will be used (default)
+# false: indent_func_call_param will NOT be used
+#
+# Default: true
+use_indent_func_call_param      = true     # true/false
+
+# The value of the indentation for a continuation line is calculated
+# differently if the statement is:
+# - a declaration: your case with QString fileName ...
+# - an assignment: your case with pSettings = new QSettings( ...
+#
+# At the second case the indentation value might be used twice:
+# - at the assignment
+# - at the function call (if present)
+#
+# To prevent the double use of the indentation value, use this option with the
+# value 'true'.
+#
+# true:  indent_continue will be used only once
+# false: indent_continue will be used every time (default)
+use_indent_continue_only_once   = false    # true/false
+
+# The value might be used twice:
+# - at the assignment
+# - at the opening brace
+#
+# To prevent the double use of the indentation value, use this option with the
+# value 'true'.
+#
+# true:  indentation will be used only once
+# false: indentation will be used every time (default)
+indent_cpp_lambda_only_once     = false    # true/false
+
+# Whether sp_after_angle takes precedence over sp_inside_fparen. This was the
+# historic behavior, but is probably not the desired behavior, so this is off
+# by default.
+use_sp_after_angle_always       = false    # true/false
+
+# Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,
+# this tries to format these so that they match Qt's normalized form (i.e. the
+# result of QMetaObject::normalizedSignature), which can slightly improve the
+# performance of the QObject::connect call, rather than how they would
+# otherwise be formatted.
+#
+# See options_for_QT.cpp for details.
+#
+# Default: true
+use_options_overriding_for_qt_macros = true     # true/false
+
+# If true: the form feed character is removed from the list
+# of whitespace characters.
+# See https://en.cppreference.com/w/cpp/string/byte/isspace
+use_form_feed_no_more_as_whitespace_character = false    # true/false
+
+#
+# Warn levels - 1: error, 2: warning (default), 3: note
+#
+
+# (C#) Warning is given if doing tab-to-\t replacement and we have found one
+# in a C# verbatim string literal.
+#
+# Default: 2
+warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
+
+# Limit the number of loops.
+# Used by uncrustify.cpp to exit from infinite loop.
+# 0: no limit.
+debug_max_number_of_loops       = 0        # number
+
+# Set the number of the line to protocol;
+# Used in the function prot_the_line if the 2. parameter is zero.
+# 0: nothing protocol.
+debug_line_number_to_protocol   = 0        # number
+
+# Set the number of second(s) before terminating formatting the current file,
+# 0: no timeout.
+# only for linux
+debug_timeout                   = 0        # number
+
+# Meaning of the settings:
+#   Ignore - do not do any changes
+#   Add    - makes sure there is 1 or more space/brace/newline/etc
+#   Force  - makes sure there is exactly 1 space/brace/newline/etc,
+#            behaves like Add in some contexts
+#   Remove - removes space/brace/newline/etc
+#
+#
+# - Token(s) can be treated as specific type(s) with the 'set' option:
+#     `set tokenType tokenString [tokenString...]`
+#
+#     Example:
+#       `set BOOL __AND__ __OR__`
+#
+#     tokenTypes are defined in src/token_enum.h, use them without the
+#     'CT_' prefix: 'CT_BOOL' => 'BOOL'
+#
+#
+# - Token(s) can be treated as type(s) with the 'type' option.
+#     `type tokenString [tokenString...]`
+#
+#     Example:
+#       `type int c_uint_8 Rectangle`
+#
+#     This can also be achieved with `set TYPE int c_uint_8 Rectangle`
+#
+#
+# To embed whitespace in tokenStrings use the '\' escape character, or quote
+# the tokenStrings. These quotes are supported: "'`
+#
+#
+# - Support for the auto detection of languages through the file ending can be
+#   added using the 'file_ext' command.
+#     `file_ext langType langString [langString..]`
+#
+#     Example:
+#       `file_ext CPP .ch .cxx .cpp.in`
+#
+#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
+#
+#
+# - Custom macro-based indentation can be set up using 'macro-open',
+#   'macro-else' and 'macro-close'.
+#     `(macro-open | macro-else | macro-close) tokenString`
+#
+#     Example:
+#       `macro-open  BEGIN_TEMPLATE_MESSAGE_MAP`
+#       `macro-open  BEGIN_MESSAGE_MAP`
+#       `macro-close END_MESSAGE_MAP`
+#
+#
+# option(s) with 'not default' value: 0
+#

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,6 @@
 {
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": [
-        "platformio.platformio-ide"
-    ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["platformio.platformio-ide"],
+  "unwantedRecommendations": ["ms-vscode.cpptools-extension-pack"]
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This work is licensed under a
 [cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
 [cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
 
-# Easyest Methode  
+# Easyest Methode
 
 Use Web OTA for upload the code https://ota.apper-solaire.org/ and select your installation.
 
@@ -21,7 +21,7 @@ after upload, connect to AP Wifi "dimmer" and connect to your own network
 
 # Methode for Advanced users ( VS Code)
 
-# 01 - Install of  Visual Studio Code
+# 01 - Install of Visual Studio Code
 
 To transfer the code to the microcontroller (ESP8266 or Robotdyn) it is necessary to install[ Visual Studio Code](https://code.visualstudio.com/).
 
@@ -80,36 +80,32 @@ There are different versions available depending on what you are using as a dimm
 [![image-1651775770647.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651775770647.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651775770647.png)
 
 1. PowerSupplyACdimmer is used for old version of Robotdyn dimmer,  
-    this is the easiest version to install, it was compatible with the daughterboards supplied with the PV router V1.2 TTGO  
-    the recommended maximum power is 5A (and not 8A as indicated by the manufacturer)  
-    ( D0 and D1(zc) are used )  
-    the Dallas probe uses D2  
+   this is the easiest version to install, it was compatible with the daughterboards supplied with the PV router V1.2 TTGO  
+   the recommended maximum power is 5A (and not 8A as indicated by the manufacturer)  
+   ( D0 and D1(zc) are used )  
+   the Dallas probe uses D2
 
-
-    [![image-1651775952029.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651775952029.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651775952029.png)
+   [![image-1651775952029.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651775952029.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651775952029.png)
 
 2. StandAlone is used to later add a Robotdyn dimmer to your ESP. <div>there are different versions supporting more or less power,  
-    on the smallest pod, the maximum recommended power is 5A (and not 8A as indicated by the manufacturer)  
-    on the 16A model, I think you should not exceed 12A -&gt; ~2500W (to be tested)  
-    ( D5 and D6(zc) are used )  
-    The Dallas probe uses D7
-    [![image-1651775990428.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651775990428.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651775990428.png)
-    
+   on the smallest pod, the maximum recommended power is 5A (and not 8A as indicated by the manufacturer)  
+   on the 16A model, I think you should not exceed 12A -&gt; ~2500W (to be tested)  
+   ( D5 and D6(zc) are used )  
+   The Dallas probe uses D7
+   [![image-1651775990428.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651775990428.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651775990428.png)
 
-3. SSR-JOTTA is used to live control an SSR The - connects to the GND and D1 to the + of the Jotta 
-The Dallas probe uses D2
-[![image-1651776015419.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651776015419.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651776015419.png)
+3. SSR-JOTTA is used to live control an SSR The - connects to the GND and D1 to the + of the Jotta
+   The Dallas probe uses D2
+   [![image-1651776015419.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651776015419.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651776015419.png)
 
 4. POWERSUPPLY2022 is for the 2022 version of the Robotdyn dimmer.  
-    it requires a TTL adapter for the 1st programming.  
-    the jumper between vdd and 3.3V must be removed during TTL programming  
-    then put back when connecting the assembly to the 220V
-    
-      
-    The Dallas probe uses pin 14 - GND at 16 and 3.3v at 12
+   it requires a TTL adapter for the 1st programming.  
+   the jumper between vdd and 3.3V must be removed during TTL programming  
+   then put back when connecting the assembly to the 220V
 
-    [![image-1651776030344.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651776030344.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651776030344.png)
-    
+   The Dallas probe uses pin 14 - GND at 16 and 3.3v at 12
+
+   [![image-1651776030344.png](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/scaled-1680-/image-1651776030344.png)](https://pvrouteur.apper-solaire.org/uploads/images/gallery/2022-05/image-1651776030344.png)
 
 Once the version has been chosen, thanks to VS you will load the firmware and the HTML pages of the router into the microcontroller
 
@@ -117,7 +113,7 @@ Once the version has been chosen, thanks to VS you will load the firmware and th
 
 Then you can directly upload the code remotely with the /update page of the router
 
-# 04 -  Remote code upload
+# 04 - Remote code upload
 
 Uploading is done with Visual Studio Code (VS) using the PlatformIO tab
 
@@ -160,97 +156,100 @@ it will memorize your Wi-Fi connection confirmations even after a firmware updat
 
 For more details: [https://www.raspberryme.com/wifimanager-avec-esp8266-connexion-automatique-parametre-personnalise-et-gestion-de-votre-ssid-et-mot-de-passe/](https://www.raspberryme.com/wifimanager-avec-esp8266-connexion-automatique-parametre-personnalise-et-gestion-de-votre-ssid-et-mot-de-passe/)
 
+---
 
------
 Old Documentation
 
+# # Distant dimmer for discharge PV surplus
 
-# # Distant dimmer for discharge PV surplus 
-
-I remaster the distant dimmer with the new ALL in dimmer from Robotdyn ( and support 8A !! ) 
+I remaster the distant dimmer with the new ALL in dimmer from Robotdyn ( and support 8A !! )
 
 <a href="https://robotdyn.com/diy-iot-ac-dimmer-kit-esp8266-wi-fi-d1-mini-for-ac-110-240v-dimming-control.html"><img src="https://robotdyn.com/pub/media/catalog/product/cache/3c7e6817bfdaeedae5fc1f56c1800828/i/o/iotdimmer_angle2_esp_logo.jpg" align="left" height="300"  ></a>
 
-
 ## Installation
 
-make a git clone of the project and use Visual Studio Code for build and upload to the board. 
+make a git clone of the project and use Visual Studio Code for build and upload to the board.
 
-### for the dimmer with AC and Wemos on board 
-by default, D0 and D1 is used and solt on the board. 
+### for the dimmer with AC and Wemos on board
+
+by default, D0 and D1 is used and solt on the board.
 D2 can be used by a Dallas 18b20, I explaint after how to make the small board
 
+### for StandAlone Boards
 
-### for StandAlone Boards 
-D5 D6 and D7 is configured (configured for a lolin NodeMCU) 
+D5 D6 and D7 is configured (configured for a lolin NodeMCU)
 <a href="https://robotdyn.com/diy-iot-ac-dimmer-kit-esp8266-wi-fi-d1-mini-for-ac-110-240v-dimming-control.html"><img src="https://ae01.alicdn.com/kf/H2f0d4aa49d694098a1f4c27bb42b50de7.jpg" align="left" height="300"  ></a>
 
-On Visual Studio upload firmware AND filesystem. 
+On Visual Studio upload firmware AND filesystem.
 
-![Alt text](./images/front.png) 
+![Alt text](./images/front.png)
 
-###  First Start
+### First Start
 
-at the first start, the wemos use the Wifimanager for configure the Wifi. 
+at the first start, the wemos use the Wifimanager for configure the Wifi.
 It create a new Wifi AP 'dimmer', connect on it at 192.168.4.1 and configure your Wifi
 
 ```mermaid
 sequenceDiagram
-Start -->> New Wifi : 
+Start -->> New Wifi :
 New Wifi -->> Configure: 192.198.4.1
-Configure -->> Start : wifi configured 
+Configure -->> Start : wifi configured
 Start  -->> Run : Open Website and Dim
 ```
 
 ### Update
 
-You can update your firmware directly by the url /update 
-it's open OTA web page, and you can push the firmware or filesystem. 
+You can update your firmware directly by the url /update
+it's open OTA web page, and you can push the firmware or filesystem.
 
-for generating firmware, on Visualstudio/ plateform IO, use the build option 
-the build firmware is stored at .pio\build\d1_mini\firmware.elf folder 
-
-
+for generating firmware, on Visualstudio/ plateform IO, use the build option
+the build firmware is stored at .pio\build\d1_mini\firmware.elf folder
 
 ## CHANGE POWER ( for control )
-You can control the power by an HTTP request : 
 
-Control :  http://IP/?POWER=xx
-the max power limit is configured on the config.html page 
+You can control the power by an HTTP request :
+
+Control : http://IP/?POWER=xx
+the max power limit is configured on the config.html page
 
 ```mermaid
 sequenceDiagram
 Website -->> Dimmer : ?POWER=x
 Dimmer -->> Website : Apply
 ```
-you can send the command by you domotic server or your pv router 
 
-### Use with Pv router 
+you can send the command by you domotic server or your pv router
 
-You can control directly the dimmer with this PV router code 
+### Use with Pv router
+
+You can control directly the dimmer with this PV router code
 https://github.com/xlyric/pv-router-esp32
 
 It use this pv routeur, <br>
 <a href="https://www.helloasso.com/associations/apper/formulaires/4"><img src="https://forum.apper-solaire.org/download/file.php?id=13773" align="down" height="300"  ></a>
 <br>
-<a href="https://www.helloasso.com/associations/apper/formulaires/4">The board was sold by a French Association ( APPER ) </a> and a TTGO Tdisplay, A SCT013-30 and AC12 power supply need to be bought separatly 
-The board is open source and freely for non commercial usage. 
+<a href="https://www.helloasso.com/associations/apper/formulaires/4">The board was sold by a French Association ( APPER ) </a> and a TTGO Tdisplay, A SCT013-30 and AC12 power supply need to be bought separatly
+The board is open source and freely for non commercial usage.
 
 ### Chaine dimmer
+
 You can now chaine multiple dimmers
-2 options : 
+2 options :
 equal : send the same command to the other dimmer
-delest (surplus) : send command to the other dimmer when the maximum power is reached on the first dimmer. 
+delest (surplus) : send command to the other dimmer when the maximum power is reached on the first dimmer.
 
 ### Dallas probe
+
 You can use dallas 18b20 Probe for limit the temperature of your water tank
-the limit temp configuration is on /config.html page. 
+the limit temp configuration is on /config.html page.
 
 ### MQTT configuration
-if you need a password for connect to your mosquitto (MQTT) serveur, the information of connection is in the file config.h 
+
+if you need a password for connect to your mosquitto (MQTT) serveur, the information of connection is in the file config.h
 
 ## Note on Robotdyn librairie
-with actual version of arduino GUI or VS, the librairie not working ( memory problem ) 
+
+with actual version of arduino GUI or VS, the librairie not working ( memory problem )
 I modify the librairie and is called in the lib_deps variable
 lib_deps = https://github.com/xlyric/RBDDimmer
 
@@ -258,25 +257,26 @@ and called by plateformio.ini file
 
 ## Create the Dallas board
 
-on a test plate, solder the long female pin from your Wemos D1 mini 
+on a test plate, solder the long female pin from your Wemos D1 mini
 
-![Alt text](./images/1.jpg) 
+![Alt text](./images/1.jpg)
 
-( I cut the 3rd pin ( RX ) I use the place for GND connector ) 
+( I cut the 3rd pin ( RX ) I use the place for GND connector )
 
-solder a 5.6kOhms resistance between 3.3V hole ( first hole ) 
-and D2 ( last hole ) 
-and sold 3.3V - GND and D2 to your Dallas 18b20 
-or add connector 
+solder a 5.6kOhms resistance between 3.3V hole ( first hole )
+and D2 ( last hole )
+and sold 3.3V - GND and D2 to your Dallas 18b20
+or add connector
 
-![Alt text](images/3.jpg) 
+![Alt text](images/3.jpg)
 
-you can now connect the board to the main board 
+you can now connect the board to the main board
 
 ![Alt text](./images/4.jpg)
 ![Alt text](./images/5.jpg)
 
 ### Print Dallas board
-A printed Board look like this 
+
+A printed Board look like this
 
 <img src="https://forum.apper-solaire.org/download/file.php?id=13769" align="left" height="300" >

--- a/data/config-AP.html
+++ b/data/config-AP.html
@@ -1,684 +1,745 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span><br>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span><br>
-                        <span>%NAME%</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div><!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active" id="menu_mqtt" hidden >
-                    <a class="nav-link" href="/mqtt.html">
-                        <i class="fas fa-fw fa-book"></i>
-                        <span>Configuration MQTT</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/minuteur.html">
-                        <i class="fas fa-fw fa-moon"></i>
-                        <span>Minuteur d'appoint</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/log.html">
-                        <i class="fas fa-fw fa-info"></i>
-                        <span>Console logs</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/update">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>OTA</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
-                        <!-- Sidebar Toggle (Topbar) -->
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item dropdown no-arrow mx-1">
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
-						<p class="mb-4">Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur la flash après l'avoir appliquée.</p>
-                        <p class="mb-4">page rapide d'aide : <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a></p>
-
- 
-
-                        <!-- Content Row -->
-                        <div class="row">
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="state">%STATE%</span>(&#37;)
-                                                    <span id="power">%POWER%</span>(W)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="sigma">%SIGMA%</span>(°C)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Content Row -->
-                        <div class="row">
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Sauvegarder sur la flash</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="save">
-                                                        <a href="#">SAUVEGARDER</a>
-                                                    </span>
-                                                    <br>
-                                                    <span id="savemsg"></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-download fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Mise en route du dimmer</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span ><a href="#" id="ONOFF">Reading State</a></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="card position-relative">
-                                <div class="card-header py-3">
-                                    <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
-                                    <span id="saveform"></span>
-                                </div>
-                                <div class="card-body">
-                                    <div class="col-lg-12">
-                                            <form
-                                                class="user"
-                                                id="formulaire"
-                                                method="post"
-                                                action=""
-                                            >
-
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">Max Temp (°C)</div>
-                                                            <div class="col-sm-3">Trigger (&percnt;)</div>
-                                                            <div class="col-sm-3">Min Power (&percnt;)</div>
-                                                            <div class="col-sm-3">Max Power (&percnt;)</div>
-                                                                                                                    </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxtemp"
-                                                                    placeholder="%MAXTEMP%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="trigger"
-                                                                    placeholder="%TRIGGER%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="minpow"
-                                                                    placeholder="%MINPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxpow"
-                                                                    placeholder="%MAXPOW%"
-                                                                >
-                                                            </div>
-</div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) ">Charge 1 (W) ( dimmer )ℹ 
-                                                                <img height="40" alt="dimmer" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII=">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) ">Charge 2 (W) ( Jotta ) ℹ 
-                                                                <img height="40" alt="Jotta" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) ">Charge 3 (W) ( relay2 ) ℹ 
-                                                                <img height="40" alt="relay2"  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg==">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge1"
-                                                                    placeholder="%CHARGE1%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge2"
-                                                                    placeholder="%CHARGE2%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge3"
-                                                                    placeholder="%CHARGE3%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                               
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Child</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">Child Dimmer IP</div>
-                                                            <div class="col-sm-4">Child Dimmer Mode</div>
-                                                            <div class="col-sm-4" id="dimmer-url">
-                                                                <!-- L'url sera ajoutée ici -->
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="child"
-                                                                    placeholder="%CHILD%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <select id="delester" class="form-control form-control-user">
-                                                                    <option value="off">off</option>
-                                                                    <option value="delester">délester</option>
-                                                                    <option value="equal">égal</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Dimmer Name</div>
-                                                            <div class="col-sm-4" id="dimmer-mDNS">
-                                                                <!-- Le nom mDNS sera rajouté ici-->
-                                                            </div>
-                                                        </div>
-
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="dimmername"
-                                                                    placeholder="%DIMMERNAME%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative" id="menu_mqtt" hidden >
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary" >Pilote MQTT</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT state dimmer subscription (or : none)</a></div>
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT dimmer temp subscription (or : none)</a></div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribePV"
-                                                                    placeholder="%SUBSCRIBEPV%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribeTEMP"
-                                                                    placeholder="%SUBSCRIBETEMP%"
-                                                                >
-                                                            </div>
-                                                        </div>   
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Puissance de démarrage</div>
-                                                            <div class="col-sm-6">Etat au démarrage</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="startingpow"
-                                                                    placeholder="%STARTINGPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <select id="dimmer_on_off" class="form-control form-control-user">
-                                                                    <option value="1">on</option>
-                                                                    <option value="0">off</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                </div>
-                                            </div>
-                                            <br>
-                                            <div class="card position-relative" id="DALLAS-LOCAL">
-                                                <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
-                                                    <span id="saveform"></span>
-                                                </div>
-                                                <div class="card-body">
-                                                    <div class="form-group row">
-
-                                                        <div class="col-sm-6">
-                                                            Adresse sonde DALLAS maitre
-                                                            <br><br>
-                                                            <b>Sonde présentes: </b>
-                                                            <span id="dallas"></span>
-                                                        </div>
-                                                        <div class="col-sm-6">
-                                                            <input
-                                                                type="text"
-                                                                class="form-control form-control-user"
-                                                                id="DALLAS"
-                                                                placeholder="%DALLAS%"
-                                                            >
-                                                        </div>    
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!--  fin du formumaire et envoie -->
-                                    <input type="submit" value=" Application des paramètres" class="btn btn-primary btn-user btn-block">
-                                    
-                                    <hr>
-                                </div>
-                                <hr>
-                            </div>
-                        </div>
-
-                </div>
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span><br />
+            <span id="RSSI">RSSI : %RSSI% dBm</span><br />
+            <span>%NAME%</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active" id="menu_mqtt" hidden>
+          <a class="nav-link" href="/mqtt.html">
+            <i class="fas fa-fw fa-book"></i>
+            <span>Configuration MQTT</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/minuteur.html">
+            <i class="fas fa-fw fa-moon"></i>
+            <span>Minuteur d'appoint</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/log.html">
+            <i class="fas fa-fw fa-info"></i>
+            <span>Console logs</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/update">
+            <i class="fas fa-fw fa-download"></i>
+            <span>OTA</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
             </div>
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item dropdown no-arrow mx-1"></li>
+              <div class="topbar-divider d-none d-sm-block"></div>
+            </ul>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
+            <p class="mb-4">
+              Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur
+              la flash après l'avoir appliquée.
+            </p>
+            <p class="mb-4">
+              page rapide d'aide :
+              <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a>
+            </p>
 
             <!-- Content Row -->
-            <script type="text/javascript"> 
+            <div class="row">
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>(&#37;) <span id="power">%POWER%</span>(W)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>(°C)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Sauvegarder sur la flash
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="save">
+                            <a href="#">SAUVEGARDER</a>
+                          </span>
+                          <br />
+                          <span id="savemsg"></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-download fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Mise en route du dimmer
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span><a href="#" id="ONOFF">Reading State</a></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-6">
+              <div class="card position-relative">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
+                  <span id="saveform"></span>
+                </div>
+                <div class="card-body">
+                  <div class="col-lg-12">
+                    <form class="user" id="formulaire" method="post" action="">
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-3">Max Temp (°C)</div>
+                            <div class="col-sm-3">Trigger (&percnt;)</div>
+                            <div class="col-sm-3">Min Power (&percnt;)</div>
+                            <div class="col-sm-3">Max Power (&percnt;)</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxtemp"
+                                placeholder="%MAXTEMP%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="trigger"
+                                placeholder="%TRIGGER%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="minpow"
+                                placeholder="%MINPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxpow"
+                                placeholder="%MAXPOW%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) "
+                            >
+                              Charge 1 (W) ( dimmer )ℹ
+                              <img
+                                height="40"
+                                alt="dimmer"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII="
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) "
+                            >
+                              Charge 2 (W) ( Jotta ) ℹ
+                              <img
+                                height="40"
+                                alt="Jotta"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC"
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) "
+                            >
+                              Charge 3 (W) ( relay2 ) ℹ
+                              <img
+                                height="40"
+                                alt="relay2"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg=="
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge1"
+                                placeholder="%CHARGE1%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge2"
+                                placeholder="%CHARGE2%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge3"
+                                placeholder="%CHARGE3%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
 
-      //<!-- rafraichissement valeurs -->
-setInterval(function refreshsend( ) {
-        $.getJSON('/state', function(data) {
-          // Récupérer les données du JSON
-            var dimmer = data.dimmer;
-            var temperature = data.temperature;
-            var power= data.power;
-            var onoff = data.onoff;
-          document.getElementById("state").innerHTML = dimmer;
-          document.getElementById("sigma").innerHTML = temperature;
-          document.getElementById("power").innerHTML = power;
-          onoff = onoff ? "ON" : "OFF";
-          $("#ONOFF").text(onoff);
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Child</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-4">Child Dimmer IP</div>
+                            <div class="col-sm-4">Child Dimmer Mode</div>
+                            <div class="col-sm-4" id="dimmer-url">
+                              <!-- L'url sera ajoutée ici -->
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="child"
+                                placeholder="%CHILD%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <select id="delester" class="form-control form-control-user">
+                                <option value="off">off</option>
+                                <option value="delester">délester</option>
+                                <option value="equal">égal</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">Dimmer Name</div>
+                            <div class="col-sm-4" id="dimmer-mDNS">
+                              <!-- Le nom mDNS sera rajouté ici-->
+                            </div>
+                          </div>
 
-          if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
-            } else {
-                    $('#alertBox').fadeOut();
-            }
-          
-          });
-}, 5000);
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="dimmername"
+                                placeholder="%DIMMERNAME%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="menu_mqtt" hidden>
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Pilote MQTT</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT state dimmer subscription (or : none)</a
+                              >
+                            </div>
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT dimmer temp subscription (or : none)</a
+                              >
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribePV"
+                                placeholder="%SUBSCRIBEPV%"
+                              />
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribeTEMP"
+                                placeholder="%SUBSCRIBETEMP%"
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">Puissance de démarrage</div>
+                            <div class="col-sm-6">Etat au démarrage</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="startingpow"
+                                placeholder="%STARTINGPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <select id="dimmer_on_off" class="form-control form-control-user">
+                                <option value="1">on</option>
+                                <option value="0">off</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="DALLAS-LOCAL">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              Adresse sonde DALLAS maitre
+                              <br /><br />
+                              <b>Sonde présentes: </b>
+                              <span id="dallas"></span>
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="DALLAS"
+                                placeholder="%DALLAS%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                  <!--  fin du formumaire et envoie -->
+                  <input
+                    type="submit"
+                    value=" Application des paramètres"
+                    class="btn btn-primary btn-user btn-block"
+                  />
 
+                  <hr />
+                </div>
+                <hr />
+              </div>
+            </div>
+          </div>
+        </div>
 
-setInterval(function refreshsend( ) {
-        $.getJSON('/state_dallas', function(data) {
-          // affichage des dallas et les Température ( boucle sur les dallas )
-            var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
-            var dallasNumber; 
-        // Extraction des données des capteurs Dallas du JSON
-        for (var key in data) {
-            if (key.startsWith('dallas')) {
-                dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
-                var dallasTemperature = data[key];
-                var dallasAddressKey = 'addr' + dallasNumber;
-                var dallasAddress = data[dallasAddressKey];
-                dallasData[dallasNumber] = {
+        <!-- Content Row -->
+        <script type="text/javascript">
+          //<!-- rafraichissement valeurs -->
+          setInterval(function refreshsend() {
+            $.getJSON("/state", function (data) {
+              // Récupérer les données du JSON
+              var dimmer = data.dimmer;
+              var temperature = data.temperature;
+              var power = data.power;
+              var onoff = data.onoff;
+              document.getElementById("state").innerHTML = dimmer;
+              document.getElementById("sigma").innerHTML = temperature;
+              document.getElementById("power").innerHTML = power;
+              onoff = onoff ? "ON" : "OFF";
+              $("#ONOFF").text(onoff);
+
+              if (data.alerte && data.alerte.trim() != "") {
+                const alertContainer = document.getElementById("alertContainer");
+                alertContainer.innerHTML = "Alerte : " + data.alerte;
+                $("#alertBox").fadeIn();
+              } else {
+                $("#alertBox").fadeOut();
+              }
+            });
+          }, 5000);
+
+          setInterval(function refreshsend() {
+            $.getJSON("/state_dallas", function (data) {
+              // affichage des dallas et les Température ( boucle sur les dallas )
+              var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
+              var dallasNumber;
+              // Extraction des données des capteurs Dallas du JSON
+              for (var key in data) {
+                if (key.startsWith("dallas")) {
+                  dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
+                  var dallasTemperature = data[key];
+                  var dallasAddressKey = "addr" + dallasNumber;
+                  var dallasAddress = data[dallasAddressKey];
+                  dallasData[dallasNumber] = {
                     temperature: dallasTemperature,
-                    address: dallasAddress
-                };
-            }
-        }
-                    // Affichage des données des capteurs Dallas dans la page HTML
-            var dallasHtml = '';
-            for ( dallasNumber in dallasData) {
-                dallasHtml += '<p>Dallas sensor ' + dallasNumber + ': ' + dallasData[dallasNumber].temperature + '°C <br>Address: ' + dallasData[dallasNumber].address + '</p>';
-            }
-            document.getElementById("dallas").innerHTML = dallasHtml;
+                    address: dallasAddress,
+                  };
+                }
+              }
+              // Affichage des données des capteurs Dallas dans la page HTML
+              var dallasHtml = "";
+              for (dallasNumber in dallasData) {
+                dallasHtml +=
+                  "<p>Dallas sensor " +
+                  dallasNumber +
+                  ": " +
+                  dallasData[dallasNumber].temperature +
+                  "°C <br>Address: " +
+                  dallasData[dallasNumber].address +
+                  "</p>";
+              }
+              document.getElementById("dallas").innerHTML = dallasHtml;
+            });
+          }, 5000);
 
+          function sendmode(mode) {
+            $.get("/get", { send: mode }).done(function (data) {
+              document.getElementById("sendmode").innerHTML = "Request sent";
+              document.getElementById("sendmode2").innerHTML = "Request sent";
+            });
+          }
+
+          function save() {
+            $.get("/get", { save: "yes" }).done(function (data) {});
+          }
+        </script>
+
+        <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+        <script>
+          if (typeof jQuery == "undefined") {
+            document.write('<script src="/js/jquery.min.js"><\/script>');
+          }
+        </script>
+
+        <script>
+          $(function () {
+            $('[data-toggle="popover"]').popover();
           });
-}, 5000);
-	
-function sendmode (mode) {
 
-		$.get( "/get", { send: 	mode } )
-		.done(function(data) {
-		document.getElementById("sendmode").innerHTML = "Request sent";
-		document.getElementById("sendmode2").innerHTML = "Request sent";
-		});
+          <!--- sauvegarde de la configuration -->
+          $("#save").click(function () {
+            $.get("/get", { save: "yes" }).done(function (data) {
+              $("#savemsg").text("Configuration sauvegardée").show().fadeOut(5000);
+            });
+          });
 
+          $("#ONOFF").click(function () {
+            $.get("/onoff").done(function (data) {
+              // si la data est 1 alors on affiche ON sinon OFF
+              if (data == 1) {
+                data = "ON";
+              } else {
+                data = "OFF";
+              }
+              $("#ONOFF").text(data);
+            });
+          });
 
-}
+          $("#formulaire").submit(function () {
+            var data = {
+              hostname: $("#hostname").val(),
+              port: $("#port").val(),
+              Publish: $("#Publish").val(),
+              maxtemp: $("#maxtemp").val(),
+              startingpow: $("#startingpow").val(),
+              minpow: $("#minpow").val(),
+              maxpow: $("#maxpow").val(),
+              child: $("#child").val(),
+              SubscribePV: $("#SubscribePV").val(),
+              SubscribeTEMP: $("#SubscribeTEMP").val(),
+              mode: $("#delester").val(),
+              charge1: $("#charge1").val(),
+              charge2: $("#charge2").val(),
+              charge3: $("#charge3").val(),
+              DALLAS: $("#DALLAS").val(),
+              dimmername: $("#dimmername").val(),
+              trigger: $("#trigger").val(),
+            };
 
+            $.ajax({
+              type: "GET",
+              data: data,
+              url: "get",
 
-function save () {				  
-  		$.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		
-		});		
+              success: function (retour) {
+                $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+              },
+            });
+            return false;
+          });
 
-
-}
-
-		
-		</script>
-           
-
-
-<script src="https://code.jquery.com/jquery-3.4.1.js">
-            </script>
-            <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-            </script>
-
-
-
-            <script>
-    $(function () {
-        $('[data-toggle="popover"]').popover()
-    })
-
-<!--- sauvegarde de la configuration --> 
-$( "#save" ).click(function() {
-
-    $.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		$( "#savemsg" ).text( "Configuration sauvegardée" ).show().fadeOut( 5000 );
-		});	
-});
-
-$( "#ONOFF" ).click(function() {
-  
-    $.get( "/onoff" )
-    .done(function(data) {
-        // si la data est 1 alors on affiche ON sinon OFF
-        if (data == 1) {
-            data = "ON";
-        } else {
-            data = "OFF";
-        }
-        $("#ONOFF").text(data);
-    });	
-});
-
-
-$( "#formulaire" ).submit(function() {
-
-	 var data = {'hostname':$('#hostname').val(), 'port':$('#port').val(), 'Publish':$('#Publish').val(),'maxtemp':$('#maxtemp').val(),  'startingpow':$('#startingpow').val(), 'minpow':$('#minpow').val(), 'maxpow':$('#maxpow').val(), 'child':$('#child').val(), 'SubscribePV':$('#SubscribePV').val(), 'SubscribeTEMP':$('#SubscribeTEMP').val(), 'mode':$('#delester').val() , 'charge1':$('#charge1').val() , 'charge2':$('#charge2').val() , 'charge3':$('#charge3').val(), 'DALLAS':$('#DALLAS').val(), 'dimmername':$('#dimmername').val(), 'trigger':$('#trigger').val()} 
-
-     $.ajax({
-            type: "GET",
-            data: data,
-            url: "get",
-
-            success: function(retour){
-                $( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-                     
-            }
-        });
-  return false;
-});
-
-
-
-        $(document).ready(function(){
-
+          $(document).ready(function () {
             function generateLink(dimmerValue) {
-                if (dimmerValue !== 'none') {
-                    var dimmerURL = "http://" + dimmerValue;
-                    $('#dimmer-url').html('<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + '</a>');
+              if (dimmerValue !== "none") {
+                var dimmerURL = "http://" + dimmerValue;
+                $("#dimmer-url").html(
+                  '<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + "</a>"
+                );
+              }
+            }
+
+            function generateLinkName(dimmerName) {
+              var formattedName = dimmerName.replace(/ /g, "-") + ".local"; // Replace spaces with hyphens and add .local
+              $("#dimmer-mDNS").html(formattedName); // Update the HTML content
+            }
+
+            var recupconfig = $.getJSON("/config", function (data) {
+              for (var key in data) {
+                if (data.hasOwnProperty(key)) {
+                  var element = document.getElementById(key);
+                  if (element) {
+                    element.value = data[key];
+                    if (element.type === "checkbox") {
+                      element.checked = data[key];
+                    }
+                  }
                 }
-            }
+              }
 
-		    function generateLinkName(dimmerName) {
-                        var formattedName = dimmerName.replace(/ /g, '-') + ".local";  // Replace spaces with hyphens and add .local
-                        $('#dimmer-mDNS').html(formattedName);  // Update the HTML content
-            }
-
-        var recupconfig =  $.getJSON('/config', function(data) {
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-            var element = document.getElementById(key);
-            if (element) {
-                element.value = data[key];
-                if (element.type === 'checkbox') {
-                element.checked = data[key];
-                }
-            }
-            }
-        }
-
-            // Une fois la requête terminée
-            recupconfig.done(function() {
+              // Une fois la requête terminée
+              recupconfig.done(function () {
                 // Générer le lien avec la valeur initiale
-                var dimmerValue = $('#child').val();
+                var dimmerValue = $("#child").val();
                 generateLink(dimmerValue);
-                var dimmerValue  = $('#dimmername').val();
+                var dimmerValue = $("#dimmername").val();
                 generateLinkName(dimmerValue);
-            });
+              });
 
-            $('#child').on('input', function() {
+              $("#child").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLink(dimmerValue);
-            });
+              });
 
-            $('#dimmer-mDNS').on('input', function() {
+              $("#dimmer-mDNS").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLinkName(dimmerValue);
+              });
             });
-
-
-        });
-
-});
-
-            </script>
-
-        </div>
+          });
+        </script>
+      </div>
     </div>
-</div>
-<!-- /.container-fluid -->
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- /.container-fluid -->
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2024</span>
+          <span>https://github.com/xlyric/ - 2024</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data/config.html
+++ b/data/config.html
@@ -1,684 +1,738 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span><br>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span><br>
-                        <span>%NAME%</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div><!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active" id="menu_mqtt" >
-                    <a class="nav-link" href="/mqtt.html">
-                        <i class="fas fa-fw fa-book"></i>
-                        <span>Configuration MQTT</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/minuteur.html">
-                        <i class="fas fa-fw fa-moon"></i>
-                        <span>Minuteur d'appoint</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/log.html">
-                        <i class="fas fa-fw fa-info"></i>
-                        <span>Console logs</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/update">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>OTA</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
-                        <!-- Sidebar Toggle (Topbar) -->
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item dropdown no-arrow mx-1">
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
-						<p class="mb-4">Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur la flash après l'avoir appliquée.</p>
-                        <p class="mb-4">page rapide d'aide : <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a></p>
-
- 
-
-                        <!-- Content Row -->
-                        <div class="row">
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="state">%STATE%</span>(&#37;)
-                                                    <span id="power">%POWER%</span>(W)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="sigma">%SIGMA%</span>(°C)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Content Row -->
-                        <div class="row">
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Sauvegarder sur la flash</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="save">
-                                                        <a href="#">SAUVEGARDER</a>
-                                                    </span>
-                                                    <br>
-                                                    <span id="savemsg"></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-download fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Mise en route du dimmer</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span ><a href="#" id="ONOFF">Reading State</a></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="card position-relative">
-                                <div class="card-header py-3">
-                                    <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
-                                    <span id="saveform"></span>
-                                </div>
-                                <div class="card-body">
-                                    <div class="col-lg-12">
-                                            <form
-                                                class="user"
-                                                id="formulaire"
-                                                method="post"
-                                                action=""
-                                            >
-
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">Max Temp (°C)</div>
-                                                            <div class="col-sm-3">Trigger (&percnt;)</div>
-                                                            <div class="col-sm-3">Min Power (&percnt;)</div>
-                                                            <div class="col-sm-3">Max Power (&percnt;)</div>
-                                                                                                                    </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxtemp"
-                                                                    placeholder="%MAXTEMP%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="trigger"
-                                                                    placeholder="%TRIGGER%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="minpow"
-                                                                    placeholder="%MINPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxpow"
-                                                                    placeholder="%MAXPOW%"
-                                                                >
-                                                            </div>
-</div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) ">Charge 1 (W) ( dimmer )ℹ 
-                                                                <img height="40" alt="dimmer" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII=">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) ">Charge 2 (W) ( Jotta ) ℹ 
-                                                                <img height="40" alt="Jotta" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) ">Charge 3 (W) ( relay2 ) ℹ 
-                                                                <img height="40" alt="relay2"  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg==">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge1"
-                                                                    placeholder="%CHARGE1%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge2"
-                                                                    placeholder="%CHARGE2%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge3"
-                                                                    placeholder="%CHARGE3%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                               
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Child</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">Child Dimmer IP</div>
-                                                            <div class="col-sm-4">Child Dimmer Mode</div>
-                                                            <div class="col-sm-4" id="dimmer-url">
-                                                                <!-- L'url sera ajoutée ici -->
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="child"
-                                                                    placeholder="%CHILD%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <select id="delester" class="form-control form-control-user">
-                                                                    <option value="off">off</option>
-                                                                    <option value="delester">délester</option>
-                                                                    <option value="equal">égal</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Dimmer Name</div>
-                                                            <div class="col-sm-4" id="dimmer-mDNS">
-                                                                <!-- Le nom mDNS sera rajouté ici-->
-                                                            </div>
-                                                        </div>
-
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="dimmername"
-                                                                    placeholder="%DIMMERNAME%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative" id="menu_mqtt">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary" >Pilote MQTT</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT state dimmer subscription (or : none)</a></div>
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT dimmer temp subscription (or : none)</a></div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribePV"
-                                                                    placeholder="%SUBSCRIBEPV%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribeTEMP"
-                                                                    placeholder="%SUBSCRIBETEMP%"
-                                                                >
-                                                            </div>
-                                                        </div>   
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Puissance de démarrage</div>
-                                                            <div class="col-sm-6">Etat au démarrage</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="startingpow"
-                                                                    placeholder="%STARTINGPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <select id="dimmer_on_off" class="form-control form-control-user">
-                                                                    <option value="1">on</option>
-                                                                    <option value="0">off</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                </div>
-                                            </div>
-                                            <br>
-                                            <div class="card position-relative" id="DALLAS-LOCAL">
-                                                <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
-                                                    <span id="saveform"></span>
-                                                </div>
-                                                <div class="card-body">
-                                                    <div class="form-group row">
-
-                                                        <div class="col-sm-6">
-                                                            Adresse sonde DALLAS maitre
-                                                            <br><br>
-                                                            <b>Sonde présentes: </b>
-                                                            <span id="dallas"></span>
-                                                        </div>
-                                                        <div class="col-sm-6">
-                                                            <input
-                                                                type="text"
-                                                                class="form-control form-control-user"
-                                                                id="DALLAS"
-                                                                placeholder="%DALLAS%"
-                                                            >
-                                                        </div>    
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!--  fin du formumaire et envoie -->
-                                    <input type="submit" value=" Application des paramètres" class="btn btn-primary btn-user btn-block">
-                                    
-                                    <hr>
-                                </div>
-                                <hr>
-                            </div>
-                        </div>
-
-                </div>
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span><br />
+            <span id="RSSI">RSSI : %RSSI% dBm</span><br />
+            <span>%NAME%</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active" id="menu_mqtt">
+          <a class="nav-link" href="/mqtt.html">
+            <i class="fas fa-fw fa-book"></i>
+            <span>Configuration MQTT</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/minuteur.html">
+            <i class="fas fa-fw fa-moon"></i>
+            <span>Minuteur d'appoint</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/log.html">
+            <i class="fas fa-fw fa-info"></i>
+            <span>Console logs</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/update">
+            <i class="fas fa-fw fa-download"></i>
+            <span>OTA</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
             </div>
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item dropdown no-arrow mx-1"></li>
+              <div class="topbar-divider d-none d-sm-block"></div>
+            </ul>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
+            <p class="mb-4">
+              Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur
+              la flash après l'avoir appliquée.
+            </p>
+            <p class="mb-4">
+              page rapide d'aide :
+              <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a>
+            </p>
 
             <!-- Content Row -->
-            <script type="text/javascript"> 
+            <div class="row">
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>(&#37;) <span id="power">%POWER%</span>(W)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>(°C)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Sauvegarder sur la flash
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="save">
+                            <a href="#">SAUVEGARDER</a>
+                          </span>
+                          <br />
+                          <span id="savemsg"></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-download fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Mise en route du dimmer
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span><a href="#" id="ONOFF">Reading State</a></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-6">
+              <div class="card position-relative">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
+                  <span id="saveform"></span>
+                </div>
+                <div class="card-body">
+                  <div class="col-lg-12">
+                    <form class="user" id="formulaire" method="post" action="">
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-3">Max Temp (°C)</div>
+                            <div class="col-sm-3">Trigger (&percnt;)</div>
+                            <div class="col-sm-3">Min Power (&percnt;)</div>
+                            <div class="col-sm-3">Max Power (&percnt;)</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxtemp"
+                                placeholder="%MAXTEMP%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="trigger"
+                                placeholder="%TRIGGER%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="minpow"
+                                placeholder="%MINPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxpow"
+                                placeholder="%MAXPOW%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) "
+                            >
+                              Charge 1 (W) ( dimmer )ℹ
+                              <img
+                                height="40"
+                                alt="dimmer"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII="
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) "
+                            >
+                              Charge 2 (W) ( Jotta ) ℹ
+                              <img
+                                height="40"
+                                alt="Jotta"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC"
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) "
+                            >
+                              Charge 3 (W) ( relay2 ) ℹ
+                              <img
+                                height="40"
+                                alt="relay2"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg=="
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge1"
+                                placeholder="%CHARGE1%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge2"
+                                placeholder="%CHARGE2%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge3"
+                                placeholder="%CHARGE3%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
 
-      //<!-- rafraichissement valeurs -->
-setInterval(function refreshsend( ) {
-        $.getJSON('/state', function(data) {
-          // Récupérer les données du JSON
-            var dimmer = data.dimmer;
-            var temperature = data.temperature;
-            var power= data.power;
-            var onoff = data.onoff;
-          document.getElementById("state").innerHTML = dimmer;
-          document.getElementById("sigma").innerHTML = temperature;
-          document.getElementById("power").innerHTML = power;
-          onoff = onoff ? "ON" : "OFF";
-          $("#ONOFF").text(onoff);
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Child</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-4">Child Dimmer IP</div>
+                            <div class="col-sm-4">Child Dimmer Mode</div>
+                            <div class="col-sm-4" id="dimmer-url">
+                              <!-- L'url sera ajoutée ici -->
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="child"
+                                placeholder="%CHILD%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <select id="delester" class="form-control form-control-user">
+                                <option value="off">off</option>
+                                <option value="delester">délester</option>
+                                <option value="equal">égal</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">Dimmer Name</div>
+                            <div class="col-sm-4" id="dimmer-mDNS">
+                              <!-- Le nom mDNS sera rajouté ici-->
+                            </div>
+                          </div>
 
-          if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
-            } else {
-                    $('#alertBox').fadeOut();
-            }
-          
-          });
-}, 5000);
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="dimmername"
+                                placeholder="%DIMMERNAME%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="menu_mqtt">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Pilote MQTT</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT state dimmer subscription (or : none)</a
+                              >
+                            </div>
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT dimmer temp subscription (or : none)</a
+                              >
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribePV"
+                                placeholder="%SUBSCRIBEPV%"
+                              />
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribeTEMP"
+                                placeholder="%SUBSCRIBETEMP%"
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">Puissance de démarrage</div>
+                            <div class="col-sm-6">Etat au démarrage</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="startingpow"
+                                placeholder="%STARTINGPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <select id="dimmer_on_off" class="form-control form-control-user">
+                                <option value="1">on</option>
+                                <option value="0">off</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="DALLAS-LOCAL">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              Adresse sonde DALLAS maitre
+                              <br /><br />
+                              <b>Sonde présentes: </b>
+                              <span id="dallas"></span>
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="DALLAS"
+                                placeholder="%DALLAS%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                  <!--  fin du formumaire et envoie -->
+                  <input
+                    type="submit"
+                    value=" Application des paramètres"
+                    class="btn btn-primary btn-user btn-block"
+                  />
 
+                  <hr />
+                </div>
+                <hr />
+              </div>
+            </div>
+          </div>
+        </div>
 
-setInterval(function refreshsend( ) {
-        $.getJSON('/state_dallas', function(data) {
-          // affichage des dallas et les Température ( boucle sur les dallas )
-            var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
-            var dallasNumber; 
-        // Extraction des données des capteurs Dallas du JSON
-        for (var key in data) {
-            if (key.startsWith('dallas')) {
-                dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
-                var dallasTemperature = data[key];
-                var dallasAddressKey = 'addr' + dallasNumber;
-                var dallasAddress = data[dallasAddressKey];
-                dallasData[dallasNumber] = {
+        <!-- Content Row -->
+        <script type="text/javascript">
+          //<!-- rafraichissement valeurs -->
+          setInterval(function refreshsend() {
+            $.getJSON("/state", function (data) {
+              // Récupérer les données du JSON
+              var dimmer = data.dimmer;
+              var temperature = data.temperature;
+              var power = data.power;
+              var onoff = data.onoff;
+              document.getElementById("state").innerHTML = dimmer;
+              document.getElementById("sigma").innerHTML = temperature;
+              document.getElementById("power").innerHTML = power;
+              onoff = onoff ? "ON" : "OFF";
+              $("#ONOFF").text(onoff);
+
+              if (data.alerte && data.alerte.trim() != "") {
+                const alertContainer = document.getElementById("alertContainer");
+                alertContainer.innerHTML = "Alerte : " + data.alerte;
+                $("#alertBox").fadeIn();
+              } else {
+                $("#alertBox").fadeOut();
+              }
+            });
+          }, 5000);
+
+          setInterval(function refreshsend() {
+            $.getJSON("/state_dallas", function (data) {
+              // affichage des dallas et les Température ( boucle sur les dallas )
+              var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
+              var dallasNumber;
+              // Extraction des données des capteurs Dallas du JSON
+              for (var key in data) {
+                if (key.startsWith("dallas")) {
+                  dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
+                  var dallasTemperature = data[key];
+                  var dallasAddressKey = "addr" + dallasNumber;
+                  var dallasAddress = data[dallasAddressKey];
+                  dallasData[dallasNumber] = {
                     temperature: dallasTemperature,
-                    address: dallasAddress
-                };
-            }
-        }
-                    // Affichage des données des capteurs Dallas dans la page HTML
-            var dallasHtml = '';
-            for ( dallasNumber in dallasData) {
-                dallasHtml += '<p>Dallas sensor ' + dallasNumber + ': ' + dallasData[dallasNumber].temperature + '°C <br>Address: ' + dallasData[dallasNumber].address + '</p>';
-            }
-            document.getElementById("dallas").innerHTML = dallasHtml;
+                    address: dallasAddress,
+                  };
+                }
+              }
+              // Affichage des données des capteurs Dallas dans la page HTML
+              var dallasHtml = "";
+              for (dallasNumber in dallasData) {
+                dallasHtml +=
+                  "<p>Dallas sensor " +
+                  dallasNumber +
+                  ": " +
+                  dallasData[dallasNumber].temperature +
+                  "°C <br>Address: " +
+                  dallasData[dallasNumber].address +
+                  "</p>";
+              }
+              document.getElementById("dallas").innerHTML = dallasHtml;
+            });
+          }, 5000);
 
+          function sendmode(mode) {
+            $.get("/get", { send: mode }).done(function (data) {
+              document.getElementById("sendmode").innerHTML = "Request sent";
+              document.getElementById("sendmode2").innerHTML = "Request sent";
+            });
+          }
+
+          function save() {
+            $.get("/get", { save: "yes" }).done(function (data) {});
+          }
+        </script>
+
+        <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+        <script>
+          if (typeof jQuery == "undefined") {
+            document.write('<script src="/js/jquery.min.js"><\/script>');
+          }
+        </script>
+
+        <script>
+          $(function () {
+            $('[data-toggle="popover"]').popover();
           });
-}, 5000);
-	
-function sendmode (mode) {
 
-		$.get( "/get", { send: 	mode } )
-		.done(function(data) {
-		document.getElementById("sendmode").innerHTML = "Request sent";
-		document.getElementById("sendmode2").innerHTML = "Request sent";
-		});
+          <!--- sauvegarde de la configuration -->
+          $("#save").click(function () {
+            $.get("/get", { save: "yes" }).done(function (data) {
+              $("#savemsg").text("Configuration sauvegardée").show().fadeOut(5000);
+            });
+          });
 
+          $("#ONOFF").click(function () {
+            $.get("/onoff").done(function (data) {
+              // si la data est 1 alors on affiche ON sinon OFF
+              if (data == 1) {
+                data = "ON";
+              } else {
+                data = "OFF";
+              }
+              $("#ONOFF").text(data);
+            });
+          });
 
-}
+          $("#formulaire").submit(function () {
+            var data = {
+              hostname: $("#hostname").val(),
+              port: $("#port").val(),
+              Publish: $("#Publish").val(),
+              maxtemp: $("#maxtemp").val(),
+              startingpow: $("#startingpow").val(),
+              minpow: $("#minpow").val(),
+              maxpow: $("#maxpow").val(),
+              child: $("#child").val(),
+              SubscribePV: $("#SubscribePV").val(),
+              SubscribeTEMP: $("#SubscribeTEMP").val(),
+              mode: $("#delester").val(),
+              charge1: $("#charge1").val(),
+              charge2: $("#charge2").val(),
+              charge3: $("#charge3").val(),
+              DALLAS: $("#DALLAS").val(),
+              dimmername: $("#dimmername").val(),
+              trigger: $("#trigger").val(),
+            };
 
+            $.ajax({
+              type: "GET",
+              data: data,
+              url: "get",
 
-function save () {				  
-  		$.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		
-		});		
+              success: function (retour) {
+                $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+              },
+            });
+            return false;
+          });
 
-
-}
-
-		
-		</script>
-           
-
-
-<script src="https://code.jquery.com/jquery-3.4.1.js">
-            </script>
-            <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-            </script>
-
-
-
-            <script>
-    $(function () {
-        $('[data-toggle="popover"]').popover()
-    })
-
-<!--- sauvegarde de la configuration --> 
-$( "#save" ).click(function() {
-
-    $.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		$( "#savemsg" ).text( "Configuration sauvegardée" ).show().fadeOut( 5000 );
-		});	
-});
-
-$( "#ONOFF" ).click(function() {
-  
-    $.get( "/onoff" )
-    .done(function(data) {
-        // si la data est 1 alors on affiche ON sinon OFF
-        if (data == 1) {
-            data = "ON";
-        } else {
-            data = "OFF";
-        }
-        $("#ONOFF").text(data);
-    });	
-});
-
-
-$( "#formulaire" ).submit(function() {
-
-	 var data = {'hostname':$('#hostname').val(), 'port':$('#port').val(), 'Publish':$('#Publish').val(),'maxtemp':$('#maxtemp').val(),  'startingpow':$('#startingpow').val(), 'minpow':$('#minpow').val(), 'maxpow':$('#maxpow').val(), 'child':$('#child').val(), 'SubscribePV':$('#SubscribePV').val(), 'SubscribeTEMP':$('#SubscribeTEMP').val(), 'mode':$('#delester').val() , 'charge1':$('#charge1').val() , 'charge2':$('#charge2').val() , 'charge3':$('#charge3').val(), 'DALLAS':$('#DALLAS').val(), 'dimmername':$('#dimmername').val(), 'trigger':$('#trigger').val()} 
-
-     $.ajax({
-            type: "GET",
-            data: data,
-            url: "get",
-
-            success: function(retour){
-                $( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-                     
-            }
-        });
-  return false;
-});
-
-
-
-        $(document).ready(function(){
-
+          $(document).ready(function () {
             function generateLink(dimmerValue) {
-                if (dimmerValue !== 'none') {
-                    var dimmerURL = "http://" + dimmerValue;
-                    $('#dimmer-url').html('<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + '</a>');
+              if (dimmerValue !== "none") {
+                var dimmerURL = "http://" + dimmerValue;
+                $("#dimmer-url").html(
+                  '<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + "</a>"
+                );
+              }
+            }
+
+            function generateLinkName(dimmerName) {
+              var formattedName = dimmerName.replace(/ /g, "-") + ".local"; // Replace spaces with hyphens and add .local
+              $("#dimmer-mDNS").html(formattedName); // Update the HTML content
+            }
+
+            var recupconfig = $.getJSON("/config", function (data) {
+              for (var key in data) {
+                if (data.hasOwnProperty(key)) {
+                  var element = document.getElementById(key);
+                  if (element) {
+                    element.value = data[key];
+                    if (element.type === "checkbox") {
+                      element.checked = data[key];
+                    }
+                  }
                 }
-            }
+              }
 
-		    function generateLinkName(dimmerName) {
-                        var formattedName = dimmerName.replace(/ /g, '-') + ".local";  // Replace spaces with hyphens and add .local
-                        $('#dimmer-mDNS').html(formattedName);  // Update the HTML content
-            }
-
-        var recupconfig =  $.getJSON('/config', function(data) {
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-            var element = document.getElementById(key);
-            if (element) {
-                element.value = data[key];
-                if (element.type === 'checkbox') {
-                element.checked = data[key];
-                }
-            }
-            }
-        }
-
-            // Une fois la requête terminée
-            recupconfig.done(function() {
+              // Une fois la requête terminée
+              recupconfig.done(function () {
                 // Générer le lien avec la valeur initiale
-                var dimmerValue = $('#child').val();
+                var dimmerValue = $("#child").val();
                 generateLink(dimmerValue);
-                var dimmerValue  = $('#dimmername').val();
+                var dimmerValue = $("#dimmername").val();
                 generateLinkName(dimmerValue);
-            });
+              });
 
-            $('#child').on('input', function() {
+              $("#child").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLink(dimmerValue);
-            });
+              });
 
-            $('#dimmer-mDNS').on('input', function() {
+              $("#dimmer-mDNS").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLinkName(dimmerValue);
+              });
             });
-
-
-        });
-
-});
-
-            </script>
-
-        </div>
+          });
+        </script>
+      </div>
     </div>
-</div>
-<!-- /.container-fluid -->
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- /.container-fluid -->
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2024</span>
+          <span>https://github.com/xlyric/ - 2024</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data/config.json
+++ b/data/config.json
@@ -1,1 +1,27 @@
-{"hostname":"192.168.1.22","port":1883,"Publish":"domoticz/in","IDXTemp":200,"maxtemp":60,"IDXAlarme":202,"IDX":201,"startingpow":0,"minpow":5,"maxpow":50,"child":"none","mode":"off","SubscribePV":"none","SubscribeTEMP":"none","dimmer_on_off":true,"charge":1000,"HA":true,"JEEDOM":true,"DOMOTICZ":true,"PVROUTER":"null","DALLAS":"null","name":"","charge1":1000,"charge2":0,"charge3":0}
+{
+  "hostname": "192.168.1.22",
+  "port": 1883,
+  "Publish": "domoticz/in",
+  "IDXTemp": 200,
+  "maxtemp": 60,
+  "IDXAlarme": 202,
+  "IDX": 201,
+  "startingpow": 0,
+  "minpow": 5,
+  "maxpow": 50,
+  "child": "none",
+  "mode": "off",
+  "SubscribePV": "none",
+  "SubscribeTEMP": "none",
+  "dimmer_on_off": true,
+  "charge": 1000,
+  "HA": true,
+  "JEEDOM": true,
+  "DOMOTICZ": true,
+  "PVROUTER": "null",
+  "DALLAS": "null",
+  "name": "",
+  "charge1": 1000,
+  "charge2": 0,
+  "charge3": 0
+}

--- a/data/index-AP.html
+++ b/data/index-AP.html
@@ -1,186 +1,168 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span><br>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span><br>
-                        <span>%NAME%</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
+
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span><br />
+            <span id="RSSI">RSSI : %RSSI% dBm</span><br />
+            <span>%NAME%</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <div class="topbar-divider d-none d-sm-block"></div>
             </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-    <div id="content-wrapper" class="d-flex flex-column">
+          </nav>
+          <!-- End of Topbar -->
 
-      <!-- Main Content -->
-      <div id="content">
-
-        <!-- Topbar -->
-        <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-
-          <!-- Sidebar Toggle (Topbar) -->
-
-
-
-          <!-- Topbar Navbar -->
-          <ul class="navbar-nav ml-auto">
-            <div class="topbar-divider d-none d-sm-block"></div>
-          </ul>
-
-        </nav>
-        <!-- End of Topbar -->
-
-        <!-- Begin Page Content -->
-        <div class="container-fluid">
-
-          <!-- Page Heading -->
-          <div class="d-sm-flex align-items-center justify-content-between mb-4">
-            <h1 class="h3 mb-0 text-gray-800">Dashboard-AP</h1>
-           
-          </div>
-
-          <!-- Content Row -->
-
-          <div class="row">
-
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-primary shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                      <div class="h5 mb-0 font-weight-bold text-gray-800"><span id="state">%STATE%</span></div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                    </div>
-                  </div>
-                </div>
-              </div>
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <div class="d-sm-flex align-items-center justify-content-between mb-4">
+              <h1 class="h3 mb-0 text-gray-800">Dashboard-AP</h1>
             </div>
 
-            <!-- Earnings (Monthly) Card Example -->
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-info shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                      <div class="h5 mb-0 font-weight-bold text-gray-800"><span id="sigma">%SIGMA%</span></div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+            <!-- Content Row -->
+
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>  
-         
 
-
-				
-				
-
-				<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script> 
-				
-				  <script type='text/javascript'> 
-				  
-
-setInterval(function ( ) {
-
-    $.getJSON('/state', function(data) {
-    // Récupérer les données du JSON
-
-        document.getElementById("state").innerHTML = data.power;
-        document.getElementById("sigma").innerHTML = data.temperature;
-
-      });
-}, 2000);
-
-		
-		</script >
-		
-<script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-<script>
-
-</script>
-
-            
-				  
-				  </div>
-				  
-                  
-
-				   
-				  
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <!-- /.container-fluid -->
       </div>
-      <!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
-        <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2024</span>
-        </div>
     </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
+        <div class="copyright text-center my-auto">
+          <span>https://github.com/xlyric/ - 2024</span>
+        </div>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+
+    <!-- Page script -->
+    <script type="text/javascript">
+      setInterval(function () {
+        $.getJSON("/state", function (data) {
+          // Récupérer les données du JSON
+
+          document.getElementById("state").innerHTML = data.power;
+          document.getElementById("sigma").innerHTML = data.temperature;
+        });
+      }, 2000);
+    </script>
+  </body>
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -1,392 +1,401 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span><br>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span><br>
-                        <span>%NAME%</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
+
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span><br />
+            <span id="RSSI">RSSI : %RSSI% dBm</span><br />
+            <span>%NAME%</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
+            </div>
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <li class="nav-item dropdown no-arrow">
+                <span class="mr-2 d-none d-lg-inline text-gray-600 small">
+                  <div id="time">%TIME%</div>
+                </span>
+              </li>
             </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
+            <div class="topbar-divider d-none d-sm-block"></div>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <div class="d-sm-flex align-items-center justify-content-between mb-4">
+              <h1 class="h3 mb-0 text-gray-800">Dashboard</h1>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <!-- Area Chart -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Dimmer</h6>
+                  </div>
+                  <div class="card-body">
+                    <div id="curve_chart2" style="width: auto; height: 200px"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Température</h6>
+                  </div>
+                  <div class="card-body">
+                    <div id="curve_temp" style="width: auto; height: 200px"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Etats</h6>
+                  </div>
+                  <div class="card-body">
+                    <b>Etat Ballon : </b>
+                    <h4 id="alerte">N/A</h4>
+                    <b>Etat Minuteur : </b>
+                    <h4 id="minuteur">N/A</h4>
+                    <b>Etat Relais 1 : </b>
+                    <h4 id="relais 1" style="cursor: pointer">N/A</h4>
+                    <b>Etat Relais 2 : </b>
+                    <h4 id="relais 2" style="cursor: pointer">N/A</h4>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Dallas</h6>
+                  </div>
+                  <div class="card-body">
+                    <span id="dallas"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
+        <div class="copyright text-center my-auto">
+          <span>https://github.com/xlyric/ - 2024</span>
+        </div>
+      </div>
+    </footer>
+    <!-- End of Footer -->
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <li class="nav-item dropdown no-arrow">
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
 
-                                    <span class="mr-2 d-none d-lg-inline text-gray-600 small">
-                                        <div id="time">%TIME%</div>
-                                    </span>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
 
-                            </li>
-                        </li>
-                        <div class="topbar-divider d-none d-sm-block"></div>
-                    </ul>
-                </nav>
-                <!-- End of Topbar -->
-                <!-- Begin Page Content -->
-                <div class="container-fluid">
-                    <!-- Page Heading -->
-                    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-                        <h1 class="h3 mb-0 text-gray-800">Dashboard</h1>
-                    </div>
-                    <!-- Content Row -->
-                    <div class="row">
-                        <!-- Area Chart -->
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Dimmer</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div id="curve_chart2" style=" width: auto; height: 200px;"></div>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Température</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div id="curve_temp" style=" width: auto; height: 200px;"></div>
+    <!-- Page script -->
+    <script type="text/javascript">
+      window.onload = function () {
+        horloge("time");
+      };
 
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Etats</h6>
-                                </div>
-                                <div class="card-body">
-                                <b>Etat Ballon : </b><h4 id="alerte">N/A</h4>
-                                <b>Etat Minuteur : </b><h4 id="minuteur">N/A</h4>
-                                <b>Etat Relais 1 : </b><h4 id="relais 1" style="cursor:pointer;">N/A</h4>
-                                <b>Etat Relais 2 : </b><h4 id="relais 2" style="cursor:pointer;">N/A</h4>
+      google.charts.load("current", { packages: ["corechart", "gauge"] });
+      google.charts.setOnLoadCallback(drawChart);
 
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Dallas</h6>
-                                </div>
-                                <div class="card-body">
-                                <span id="dallas"></span>
+      var chart;
+      var options = {
+        title: "Oscilloscope Mode",
+        curveType: "function",
+        legend: { position: "bottom" },
+      };
+      var data;
+      var inc;
 
-                                </div>
-                            </div>
-                        </div>
-                        <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-                        <script type="text/javascript"> 
-				  
-	window.onload=function() {
-  horloge('time');
-};			 
-				  
-				  google.charts.load('current', {'packages':['corechart','gauge']}); 
-				  google.charts.setOnLoadCallback(drawChart);
-				  
-				  var chart ;
-				  var options = { title: 'Oscilloscope Mode', curveType: 'function', legend: { position: 'bottom' } };
-				  var data ;
-				  var inc;
-				  
-				  function drawChart() {    
-
-					var optionsGauge = {           
-          redFrom: 75, 
+      function drawChart() {
+        var optionsGauge = {
+          redFrom: 75,
           redTo: 100,
-           
-          yellowFrom: 50, 
-          yellowTo: 75, 
-           
-          greenFrom: 0, 
-          greenTo: 50, 
-		  	  
+
+          yellowFrom: 50,
+          yellowTo: 75,
+
+          greenFrom: 0,
+          greenTo: 50,
+
           minorTicks: 4,
-		  
-          min: 0, 
-          max: 100, 
-           
-          
+
+          min: 0,
+          max: 100,
         };
-       
-	   	   var optionsGaugetemp = {           
-          redFrom: 80, 
+
+        var optionsGaugetemp = {
+          redFrom: 80,
           redTo: 100,
-           
-          yellowFrom: 70, 
-          yellowTo: 80, 
-           
-          greenFrom: 0, 
-          greenTo: 70, 
-		  	  
+
+          yellowFrom: 70,
+          yellowTo: 80,
+
+          greenFrom: 0,
+          greenTo: 70,
+
           minorTicks: 5,
-		  
-          min: 0, 
-          max: 100, 
-           
-          
+
+          min: 0,
+          max: 100,
         };
-	
-	// mise à jour de la jauge  --> 	
-		var gaugePA = new google.visualization.Gauge(document.getElementById('curve_chart2'));
-	    var dataGaugePA = new google.visualization.DataTable();
-	    dataGaugePA.addColumn('string', 'Puissance');
-		dataGaugePA.addColumn('number', 'Value');
-		dataGaugePA.addRows(1);
-		
-	// mise à jour de la jauge  --> 	
-		var gaugePAtemp = new google.visualization.Gauge(document.getElementById('curve_temp'));
-	    var dataGaugePAtemp = new google.visualization.DataTable();
-	    dataGaugePAtemp.addColumn('string', 'Power');
-		dataGaugePAtemp.addColumn('number', 'Value');
-		dataGaugePAtemp.addRows(1);
 
+        // mise à jour de la jauge  -->
+        var gaugePA = new google.visualization.Gauge(document.getElementById("curve_chart2"));
+        var dataGaugePA = new google.visualization.DataTable();
+        dataGaugePA.addColumn("string", "Puissance");
+        dataGaugePA.addColumn("number", "Value");
+        dataGaugePA.addRows(1);
 
-	// récupération valeur sigma et State -->
-				  
-function refreshvalue( ) {
+        // mise à jour de la jauge  -->
+        var gaugePAtemp = new google.visualization.Gauge(document.getElementById("curve_temp"));
+        var dataGaugePAtemp = new google.visualization.DataTable();
+        dataGaugePAtemp.addColumn("string", "Power");
+        dataGaugePAtemp.addColumn("number", "Value");
+        dataGaugePAtemp.addRows(1);
 
-$.getJSON('/state', function(data) {
-// Récupérer les données du JSON
-    var dimmer = data.dimmer;
-    var power = data.power;
-    var temperature = data.temperature;
-    var alerte = data.alerte;
-    var minuteur = data.minuteur;
-    var relais1 = data.relay1;
-    var relais2 = data.relay2;
+        // récupération valeur sigma et State -->
 
-    // Mettre à jour les éléments HTML
-        dataGaugePA.setValue(0, 0, "Power (W)"); 
-		dataGaugePA.setValue(0, 1, power);
-        var pmaxtemp = parseInt(power *100 / dimmer ); 
-        let pmax = isNaN(pmaxtemp) ? 1000 : pmaxtemp;
-        optionsGauge.max = pmax;
-        optionsGauge.redTo = pmax;
-        optionsGauge.redFrom = parseInt(pmax/2);
-        optionsGauge.yellowTo = parseInt(pmax/2); 
-		gaugePA.draw(dataGaugePA,optionsGauge);
-		
-		dataGaugePAtemp.setValue(0, 0, "Temp °C"); 
-		dataGaugePAtemp.setValue(0, 1, temperature);
-		gaugePAtemp.draw(dataGaugePAtemp,optionsGaugetemp);
+        function refreshvalue() {
+          $.getJSON("/state", function (data) {
+            // Récupérer les données du JSON
+            var dimmer = data.dimmer;
+            var power = data.power;
+            var temperature = data.temperature;
+            var alerte = data.alerte;
+            var minuteur = data.minuteur;
+            var relais1 = data.relay1;
+            var relais2 = data.relay2;
 
-    // recupération de l'état de sécurité
-        
-    // ecriture de "refroidissement" dans le div alerte si l'état est à 1
-        if (alerte == 1) {
-            document.getElementById("alerte").innerHTML = "Refroidissement";
-            document.getElementById("alerte").style.color = "red";
-        } else {
-            document.getElementById("alerte").innerHTML = "Normal";
-            document.getElementById("alerte").style.color = "";
-        }
+            // Mettre à jour les éléments HTML
+            dataGaugePA.setValue(0, 0, "Power (W)");
+            dataGaugePA.setValue(0, 1, power);
+            var pmaxtemp = parseInt((power * 100) / dimmer);
+            let pmax = isNaN(pmaxtemp) ? 1000 : pmaxtemp;
+            optionsGauge.max = pmax;
+            optionsGauge.redTo = pmax;
+            optionsGauge.redFrom = parseInt(pmax / 2);
+            optionsGauge.yellowTo = parseInt(pmax / 2);
+            gaugePA.draw(dataGaugePA, optionsGauge);
 
-    // ecriture de "minuteur" dans le div minuteur si l'état est à 1
-        if (minuteur == 1) {
-            document.getElementById("minuteur").innerHTML = "Minuteur";
-            document.getElementById("minuteur").style.color = "red";
-        } else {
-            document.getElementById("minuteur").innerHTML = "Non actif";
-            document.getElementById("minuteur").style.color = "";
-        }
-    
-    // ecriture de "ON" dans le div relais 1 si l'état est à 1
-        if (relais1 == 1) {
-            document.getElementById("relais 1").innerHTML = "ON";
-            document.getElementById("relais 1").style.color = "red";
-        } else {
-            document.getElementById("relais 1").innerHTML = "OFF";
-            document.getElementById("relais 1").style.color = "";
-        }
+            dataGaugePAtemp.setValue(0, 0, "Temp °C");
+            dataGaugePAtemp.setValue(0, 1, temperature);
+            gaugePAtemp.draw(dataGaugePAtemp, optionsGaugetemp);
 
-    // ecriture de "ON" dans le div relais 2 si l'état est à 1
-        if (relais2 == 1) {
-            document.getElementById("relais 2").innerHTML = "ON";
-            document.getElementById("relais 2").style.color = "red";
-        } else {
-            document.getElementById("relais 2").innerHTML = "OFF";
-            document.getElementById("relais 2").style.color = "";
-        }
+            // recupération de l'état de sécurité
 
-        if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
+            // ecriture de "refroidissement" dans le div alerte si l'état est à 1
+            if (alerte == 1) {
+              document.getElementById("alerte").innerHTML = "Refroidissement";
+              document.getElementById("alerte").style.color = "red";
             } else {
-                    $('#alertBox').fadeOut();
+              document.getElementById("alerte").innerHTML = "Normal";
+              document.getElementById("alerte").style.color = "";
+            }
+
+            // ecriture de "minuteur" dans le div minuteur si l'état est à 1
+            if (minuteur == 1) {
+              document.getElementById("minuteur").innerHTML = "Minuteur";
+              document.getElementById("minuteur").style.color = "red";
+            } else {
+              document.getElementById("minuteur").innerHTML = "Non actif";
+              document.getElementById("minuteur").style.color = "";
+            }
+
+            // ecriture de "ON" dans le div relais 1 si l'état est à 1
+            if (relais1 == 1) {
+              document.getElementById("relais 1").innerHTML = "ON";
+              document.getElementById("relais 1").style.color = "red";
+            } else {
+              document.getElementById("relais 1").innerHTML = "OFF";
+              document.getElementById("relais 1").style.color = "";
+            }
+
+            // ecriture de "ON" dans le div relais 2 si l'état est à 1
+            if (relais2 == 1) {
+              document.getElementById("relais 2").innerHTML = "ON";
+              document.getElementById("relais 2").style.color = "red";
+            } else {
+              document.getElementById("relais 2").innerHTML = "OFF";
+              document.getElementById("relais 2").style.color = "";
+            }
+
+            if (data.alerte && data.alerte.trim() != "") {
+              const alertContainer = document.getElementById("alertContainer");
+              alertContainer.innerHTML = "Alerte : " + data.alerte;
+              $("#alertBox").fadeIn();
+            } else {
+              $("#alertBox").fadeOut();
+            }
+          });
         }
 
+        setInterval(refreshvalue, 5000); // Rafraîchir les données toutes les 5 secondes
 
-
-  });
-}
- 			
-	setInterval(refreshvalue, 5000); // Rafraîchir les données toutes les 5 secondes
-
-        document.getElementById('relais 1').addEventListener('click', function() {
-            fetch('/get?relay1=2')
-                .then(response => response.text())
-                .then(data => {
-                    console.log('Response:', data);
-                    setTimeout(refreshvalue, 500);
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                });
+        document.getElementById("relais 1").addEventListener("click", function () {
+          fetch("/get?relay1=2")
+            .then((response) => response.text())
+            .then((data) => {
+              console.log("Response:", data);
+              setTimeout(refreshvalue, 500);
+            })
+            .catch((error) => {
+              console.error("Error:", error);
+            });
         });
 
-        document.getElementById('relais 2').addEventListener('click', function() {
-            fetch('/get?relay2=2')
-                .then(response => response.text())
-                .then(data => {
-                   console.log('Response:', data);
-                   setTimeout(refreshvalue, 500);
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                });
-        }); 
- 
-}
+        document.getElementById("relais 2").addEventListener("click", function () {
+          fetch("/get?relay2=2")
+            .then((response) => response.text())
+            .then((data) => {
+              console.log("Response:", data);
+              setTimeout(refreshvalue, 500);
+            })
+            .catch((error) => {
+              console.error("Error:", error);
+            });
+        });
+      }
 
-function horloge(el) {
-  if(typeof el=="string") { el = document.getElementById(el); }
-  function actualiser() {
-    var date = new Date();
-    var str = date.getHours();
-    str += ':'+(date.getMinutes()<10?'0':'')+date.getMinutes();
-    str += ':'+(date.getSeconds()<10?'0':'')+date.getSeconds();
-    el.innerHTML = str;
-  }
-  actualiser();
-  setInterval(actualiser,1000);
-}
-
-function refresh_temp() {
-        $.getJSON('/state_dallas', function(data) {
-          // affichage des dallas et les Température ( boucle sur les dallas )
-            var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
-            var dallasNumber; 
-        // Extraction des données des capteurs Dallas du JSON
-        for (var key in data) {
-            if (key.startsWith('dallas')) {
-                dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
-                var dallasTemperature = data[key];
-                var dallasAddressKey = 'addr' + dallasNumber;
-                var dallasAddress = data[dallasAddressKey];
-                dallasData[dallasNumber] = {
-                    temperature: dallasTemperature,
-                    address: dallasAddress
-                };
-            }
+      function horloge(el) {
+        if (typeof el == "string") {
+          el = document.getElementById(el);
         }
-                    // Affichage des données des capteurs Dallas dans la page HTML
-            var dallasHtml = '';
-            for ( dallasNumber in dallasData) {
-                dallasHtml += '<p>Dallas sensor ' + dallasNumber + ': ' + dallasData[dallasNumber].temperature + '°C <br>Address: ' + dallasData[dallasNumber].address + '</p>';
+        function actualiser() {
+          var date = new Date();
+          var str = date.getHours();
+          str += ":" + (date.getMinutes() < 10 ? "0" : "") + date.getMinutes();
+          str += ":" + (date.getSeconds() < 10 ? "0" : "") + date.getSeconds();
+          el.innerHTML = str;
+        }
+        actualiser();
+        setInterval(actualiser, 1000);
+      }
+
+      function refresh_temp() {
+        $.getJSON("/state_dallas", function (data) {
+          // affichage des dallas et les Température ( boucle sur les dallas )
+          var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
+          var dallasNumber;
+          // Extraction des données des capteurs Dallas du JSON
+          for (var key in data) {
+            if (key.startsWith("dallas")) {
+              dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
+              var dallasTemperature = data[key];
+              var dallasAddressKey = "addr" + dallasNumber;
+              var dallasAddress = data[dallasAddressKey];
+              dallasData[dallasNumber] = {
+                temperature: dallasTemperature,
+                address: dallasAddress,
+              };
             }
-            document.getElementById("dallas").innerHTML = dallasHtml;
+          }
+          // Affichage des données des capteurs Dallas dans la page HTML
+          var dallasHtml = "";
+          for (dallasNumber in dallasData) {
+            dallasHtml +=
+              "<p>Dallas sensor " +
+              dallasNumber +
+              ": " +
+              dallasData[dallasNumber].temperature +
+              "°C <br>Address: " +
+              dallasData[dallasNumber].address +
+              "</p>";
+          }
+          document.getElementById("dallas").innerHTML = dallasHtml;
+        });
+      }
 
-          });
-}
-
-        setInterval(refresh_temp, 5000);   // Rafraîchir les données toutes les 5 secondes
-
-
-</script>
-                    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-                    <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-                    </script>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-</div>
-<!-- /.container-fluid -->
-</div>
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
-        <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2024</span>
-        </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      setInterval(refresh_temp, 5000); // Rafraîchir les données toutes les 5 secondes
+    </script>
+  </body>
 </html>

--- a/data/lang.json
+++ b/data/lang.json
@@ -1,3 +1,3 @@
 {
-    "default_language": "fr"
+  "default_language": "fr"
 }

--- a/data/minuteur.html
+++ b/data/minuteur.html
@@ -1,280 +1,356 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv dimmer - Configuration minuteur </title>
-        <!-- Custom fonts for this template-->
-        <link href="all.css" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
-        <!-- Custom styles for this template-->
-        <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
-        <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
-        <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-        <script>
-        $( function() {
-          $( "#tabs" ).tabs();
-        } );
-        </script>
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version"></span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-plug"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar -->
-            <!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item mx-1">
-                                <a
-                                    id="heure"
-                                >
-                                </a>
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration minuteur d'appoint</h1>
-                        <div class="col-lg-6">
-                            <div id="tabs">
-                                <ul class="nav nav-tabs">
-                                  <li class="nav-item"><a class="nav-link" href="#dimmer">Configuration dimmer</a></li>
-                                  <li class="nav-item"><a class="nav-link" href="#relay1">Configuration relais 1</a></li>
-                                  <li class="nav-item"><a class="nav-link" href="#relay2">Configuration relais 2</a></li>
-                                </ul>
-
-                                <div id="dimmer">
-                                    <form class="user" id="dimmer-form" method="post" action="">
-                                      <div class="form-group">
-                                        Heure de démarrage: (format hh:mm)
-                                        <input type="text" class="form-control form-control-user" id="heure_demarrage_dimmer" placeholder="%heure_demarrage%">
-                                      </div>
-                                      <div class="form-group">
-                                        Heure d'arrêt:
-                                        <input type="text" class="form-control form-control-user" id="heure_arret_dimmer" placeholder="%heure_arret%">
-                                      </div>
-                                      <div class="form-group">
-                                        Température de consigne (°C):
-                                        <input type="number" step="1" class="form-control form-control-user" id="temperature_dimmer" placeholder="%temperature%">
-                                      </div>
-                                      <div class="form-group">
-                                        Puissance de sortie (0-100%):
-                                        <input type="number" step="1" class="form-control form-control-user" id="puissance_dimmer" placeholder="%puissance%">
-                                      </div>
-                                      <input type="submit" value="Application des paramètres dimmer" class="btn btn-primary btn-user btn-block">
-                                    </form>
-                                  </div>
-
-                                  <div id="relay1">
-                                    <form class="user" id="relay1-form" method="post" action="">
-                                      <div class="form-group">
-                                        Heure de démarrage: (format hh:mm)
-                                        <input type="text" class="form-control form-control-user" id="heure_demarrage_relay1" placeholder="%heure_demarrage%">
-                                      </div>
-                                      <div class="form-group">
-                                        Heure d'arrêt:
-                                        <input type="text" class="form-control form-control-user" id="heure_arret_relay1" placeholder="%heure_arret%">
-                                      </div>
-                                      <div class="form-group">
-                                        Température de consigne (°C):
-                                        <input type="number" step="1" class="form-control form-control-user" id="temperature_relay1" placeholder="%temperature%">
-                                      </div>
-                                      <input type="submit" value="Application des paramètres relais 1" class="btn btn-primary btn-user btn-block">
-                                    </form>
-                                  </div>
-
-                                  <div id="relay2">
-                                    <form class="user" id="relay2-form" method="post" action="">
-                                      <div class="form-group">
-                                        Heure de démarrage: (format hh:mm)
-                                        <input type="text" class="form-control form-control-user" id="heure_demarrage_relay2" placeholder="%heure_demarrage%">
-                                      </div>
-                                      <div class="form-group">
-                                        Heure d'arrêt:
-                                        <input type="text" class="form-control form-control-user" id="heure_arret_relay2" placeholder="%heure_arret%">
-                                      </div>
-                                      <div class="form-group">
-                                        Température de consigne (°C):
-                                        <input type="number" step="1" class="form-control form-control-user" id="temperature_relay2" placeholder="%temperature%">
-                                      </div>
-                                       <input type="submit" value="Application des paramètres relais 2" class="btn btn-primary btn-user btn-block">
-                                    </form>
-                                  </div>
-                    </div>
-                </div>
-            </div>
-            <!-- Content Row -->
-<script>
-  $(document).ready(function() {
-    // Récupération des heures de démarrage et d'arrêt depuis le serveur
-    $.get("/getminuteur?relay2", function(data) {
-      $("#heure_demarrage_relay2").val(data.heure_demarrage);
-      $("#heure_arret_relay2").val(data.heure_arret);
-      $("#temperature_relay2").val(data.temperature);
-      // Affichage de l'heure au format 2 digits
-      var heure = data.heure < 10 ? "0" + data.heure : data.heure;
-      var minute = data.minute < 10 ? "0" + data.minute : data.minute;
-      $("#heure").html( heure + ":" + minute );
-    });
-
-    $.get("/getminuteur?relay1", function(data) {
-      $("#heure_demarrage_relay1").val(data.heure_demarrage);
-      $("#heure_arret_relay1").val(data.heure_arret);
-      $("#temperature_relay1").val(data.temperature);
-    });
-
-    $.get("/getminuteur?dimmer", function(data) {
-      $("#heure_demarrage_dimmer").val(data.heure_demarrage);
-      $("#heure_arret_dimmer").val(data.heure_arret);
-      $("#temperature_dimmer").val(data.temperature);
-      $("#puissance_dimmer").val(data.puissance);
-    });
-
-    // Envoi des données de formulaire au serveur lors de la soumission du formulaire
-    $("#dimmer-form").submit(function(event) {
-      event.preventDefault();
-      var heure_demarrage = $("#heure_demarrage_dimmer").val();
-      var heure_arret = $("#heure_arret_dimmer").val();
-      var temperature = $("#temperature_dimmer").val();
-      var puissance = $("#puissance_dimmer").val();
-      $.get("/setminuteur?dimmer", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature, "puissance": puissance});
-    });
-
-    $("#relay1-form").submit(function(event) {
-      event.preventDefault();
-      var heure_demarrage = $("#heure_demarrage_relay1").val();
-      var heure_arret = $("#heure_arret_relay1").val();
-      var temperature = $("#temperature_relay1").val();
-      $.get("/setminuteur?relay1", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
-    });
-
-    $("#relay2-form").submit(function(event) {
-      event.preventDefault();
-      var heure_demarrage = $("#heure_demarrage_relay2").val();
-      var heure_arret = $("#heure_arret_relay2").val();
-      var temperature = $("#temperature_relay2").val();
-      $.get("/setminuteur?relay2", {"heure_demarrage": heure_demarrage, "heure_arret": heure_arret, "temperature": temperature});
-    });
-
-
-  });
-
-  
-  setInterval(function ( ) {
-    $.getJSON('/getminuteur', function(data) {
-        // Affichage de l'heure au format 2 digits
-        var heure = data.heure < 10 ? "0" + data.heure : data.heure;
-        var minute = data.minute < 10 ? "0" + data.minute : data.minute;
-        $("#heure").html( heure + ":" + minute );
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv dimmer - Configuration minuteur</title>
+    <!-- Custom fonts for this template-->
+    <link href="all.css" rel="stylesheet" type="text/css" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+      rel="stylesheet"
+    />
+    <!-- Custom styles for this template-->
+    <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+    <script>
+      $(function () {
+        $("#tabs").tabs();
       });
-	}, 15000);
-
-</script>
-
+    </script>
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version"></span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-plug"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
         </div>
+      </ul>
+      <!-- End of Sidebar -->
+      <!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item mx-1">
+                <a id="heure"> </a>
+              </li>
+              <div class="topbar-divider d-none d-sm-block"></div>
+            </ul>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration minuteur d'appoint</h1>
+            <div class="col-lg-6">
+              <div id="tabs">
+                <ul class="nav nav-tabs">
+                  <li class="nav-item">
+                    <a class="nav-link" href="#dimmer">Configuration dimmer</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#relay1">Configuration relais 1</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#relay2">Configuration relais 2</a>
+                  </li>
+                </ul>
+
+                <div id="dimmer">
+                  <form class="user" id="dimmer-form" method="post" action="">
+                    <div class="form-group">
+                      Heure de démarrage: (format hh:mm)
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_demarrage_dimmer"
+                        placeholder="%heure_demarrage%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Heure d'arrêt:
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_arret_dimmer"
+                        placeholder="%heure_arret%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Température de consigne (°C):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="temperature_dimmer"
+                        placeholder="%temperature%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Puissance de sortie (0-100%):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="puissance_dimmer"
+                        placeholder="%puissance%"
+                      />
+                    </div>
+                    <input
+                      type="submit"
+                      value="Application des paramètres dimmer"
+                      class="btn btn-primary btn-user btn-block"
+                    />
+                  </form>
+                </div>
+
+                <div id="relay1">
+                  <form class="user" id="relay1-form" method="post" action="">
+                    <div class="form-group">
+                      Heure de démarrage: (format hh:mm)
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_demarrage_relay1"
+                        placeholder="%heure_demarrage%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Heure d'arrêt:
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_arret_relay1"
+                        placeholder="%heure_arret%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Température de consigne (°C):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="temperature_relay1"
+                        placeholder="%temperature%"
+                      />
+                    </div>
+                    <input
+                      type="submit"
+                      value="Application des paramètres relais 1"
+                      class="btn btn-primary btn-user btn-block"
+                    />
+                  </form>
+                </div>
+
+                <div id="relay2">
+                  <form class="user" id="relay2-form" method="post" action="">
+                    <div class="form-group">
+                      Heure de démarrage: (format hh:mm)
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_demarrage_relay2"
+                        placeholder="%heure_demarrage%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Heure d'arrêt:
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="heure_arret_relay2"
+                        placeholder="%heure_arret%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Température de consigne (°C):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="temperature_relay2"
+                        placeholder="%temperature%"
+                      />
+                    </div>
+                    <input
+                      type="submit"
+                      value="Application des paramètres relais 2"
+                      class="btn btn-primary btn-user btn-block"
+                    />
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Content Row -->
+          <script>
+            $(document).ready(function () {
+              // Récupération des heures de démarrage et d'arrêt depuis le serveur
+              $.get("/getminuteur?relay2", function (data) {
+                $("#heure_demarrage_relay2").val(data.heure_demarrage);
+                $("#heure_arret_relay2").val(data.heure_arret);
+                $("#temperature_relay2").val(data.temperature);
+                // Affichage de l'heure au format 2 digits
+                var heure = data.heure < 10 ? "0" + data.heure : data.heure;
+                var minute = data.minute < 10 ? "0" + data.minute : data.minute;
+                $("#heure").html(heure + ":" + minute);
+              });
+
+              $.get("/getminuteur?relay1", function (data) {
+                $("#heure_demarrage_relay1").val(data.heure_demarrage);
+                $("#heure_arret_relay1").val(data.heure_arret);
+                $("#temperature_relay1").val(data.temperature);
+              });
+
+              $.get("/getminuteur?dimmer", function (data) {
+                $("#heure_demarrage_dimmer").val(data.heure_demarrage);
+                $("#heure_arret_dimmer").val(data.heure_arret);
+                $("#temperature_dimmer").val(data.temperature);
+                $("#puissance_dimmer").val(data.puissance);
+              });
+
+              // Envoi des données de formulaire au serveur lors de la soumission du formulaire
+              $("#dimmer-form").submit(function (event) {
+                event.preventDefault();
+                var heure_demarrage = $("#heure_demarrage_dimmer").val();
+                var heure_arret = $("#heure_arret_dimmer").val();
+                var temperature = $("#temperature_dimmer").val();
+                var puissance = $("#puissance_dimmer").val();
+                $.get("/setminuteur?dimmer", {
+                  heure_demarrage: heure_demarrage,
+                  heure_arret: heure_arret,
+                  temperature: temperature,
+                  puissance: puissance,
+                });
+              });
+
+              $("#relay1-form").submit(function (event) {
+                event.preventDefault();
+                var heure_demarrage = $("#heure_demarrage_relay1").val();
+                var heure_arret = $("#heure_arret_relay1").val();
+                var temperature = $("#temperature_relay1").val();
+                $.get("/setminuteur?relay1", {
+                  heure_demarrage: heure_demarrage,
+                  heure_arret: heure_arret,
+                  temperature: temperature,
+                });
+              });
+
+              $("#relay2-form").submit(function (event) {
+                event.preventDefault();
+                var heure_demarrage = $("#heure_demarrage_relay2").val();
+                var heure_arret = $("#heure_arret_relay2").val();
+                var temperature = $("#temperature_relay2").val();
+                $.get("/setminuteur?relay2", {
+                  heure_demarrage: heure_demarrage,
+                  heure_arret: heure_arret,
+                  temperature: temperature,
+                });
+              });
+            });
+
+            setInterval(function () {
+              $.getJSON("/getminuteur", function (data) {
+                // Affichage de l'heure au format 2 digits
+                var heure = data.heure < 10 ? "0" + data.heure : data.heure;
+                var minute = data.minute < 10 ? "0" + data.minute : data.minute;
+                $("#heure").html(heure + ":" + minute);
+              });
+            }, 15000);
+          </script>
+        </div>
+      </div>
     </div>
-</div>
-</div>
-</div>
-<!-- /.container-fluid -->
-</div>
-<!-- End of Main Content -->
-<!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- End of Main Content -->
+    <!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2024</span>
+          <span>https://github.com/xlyric/ - 2024</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- End of Content Wrapper -->
-</div>
-<!-- End of Page Wrapper -->
-<!-- Bootstrap core JavaScript-->
-
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-                    <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-                    </script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-<script></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+    <script></script>
+  </body>
 </html>

--- a/data/mqtt.json
+++ b/data/mqtt.json
@@ -1,1 +1,1 @@
-{"MQTT_USER":"mosquitto","MQTT_PASSWORD":"test-123"}
+{ "MQTT_USER": "mosquitto", "MQTT_PASSWORD": "test-123" }

--- a/data/programme.json
+++ b/data/programme.json
@@ -1,4 +1,1 @@
-{       "heure_demarrage": "16:36",
-        "heure_arret": "16:37",
-        "temperature": "50"
-    }
+{ "heure_demarrage": "16:36", "heure_arret": "16:37", "temperature": "50" }

--- a/data/relai.html
+++ b/data/relai.html
@@ -1,227 +1,278 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer  - minuteur Configuration</title>
-        <!-- Custom fonts for this template-->
-        <link href="all.css" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
-        <!-- Custom styles for this template-->
-        <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
-        <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
-        <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-        <script>
-        $( function() {
-          $( "#tabs" ).tabs();
-        } );
-        </script>
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version"></span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-plug"></i>
-                        <span>retour conso</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer - minuteur Configuration</title>
+    <!-- Custom fonts for this template-->
+    <link href="all.css" rel="stylesheet" type="text/css" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+      rel="stylesheet"
+    />
+    <!-- Custom styles for this template-->
+    <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version"></span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-plug"></i>
+            <span>retour conso</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar -->
+      <!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item mx-1">
+                <a id="heure"> </a>
+              </li>
+              <div class="topbar-divider d-none d-sm-block"></div>
             </ul>
-            <!-- End of Sidebar -->
-            <!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <!-- Sidebar Toggle (Topbar) -->
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration Relais</h1>
+            <div class="col-lg-6">
+              <div id="tabs">
+                <ul class="nav nav-tabs">
+                  <li class="nav-item">
+                    <a class="nav-link" href="#relay1">Configuration relay1</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#relay2">Configuration relay2</a>
+                  </li>
+                </ul>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item mx-1">
-                                <a
-                                    id="heure"
-                                >
-                                </a>
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration Relais</h1>
-                        <div class="col-lg-6">
-                            <div id="tabs">
-                                <ul class="nav nav-tabs">
-                                  <li class="nav-item"><a class="nav-link" href="#relay1">Configuration relay1</a></li>
-                                  <li class="nav-item"><a class="nav-link" href="#relay2">Configuration relay2</a></li>
-                                </ul>
-
-                                  <div id="relay1">
-                                    <form class="user" id="relay1-form" method="post" action="">
-                                      <div class="form-group">
-                                        Seuil de démarrage en %
-                                        <input type="text" class="form-control form-control-user" id="seuil_demarrage_relay1" placeholder="%seuil_demarrage%">
-                                      </div>
-                                      <div class="form-group">
-                                        Seuil d'arrêt en %
-                                        <input type="text" class="form-control form-control-user" id="seuil_arret_relay1" placeholder="%seuil_arret%">
-                                      </div>
-                                      <div class="form-group">
-                                        Température de consigne (°C):
-                                        <input type="number" step="1" class="form-control form-control-user" id="temperature_relay1" placeholder="%temperature%">
-                                      </div>
-                                      <input type="submit" value="Application des paramètres relay1" class="btn btn-primary btn-user btn-block">
-                                    </form>
-                                  </div>
-
-                                  <div id="relay2">
-                                    <form class="user" id="relay2-form" method="post" action="">
-                                      <div class="form-group">
-                                        Seuil de démarrage en %
-                                        <input type="text" class="form-control form-control-user" id="seuil_demarrage_relay2" placeholder="%seuil_demarrage%">
-                                      </div>
-                                      <div class="form-group">
-                                        Seuil d'arrêt en %
-                                        <input type="text" class="form-control form-control-user" id="seuil_arret_relay2" placeholder="%seuil_arret%">
-                                      </div>
-                                      <div class="form-group">
-                                        Température de consigne (°C):
-                                        <input type="number" step="1" class="form-control form-control-user" id="temperature_relay2" placeholder="%temperature%">
-                                      </div>
-                                       <input type="submit" value="Application des paramètres relay2" class="btn btn-primary btn-user btn-block">
-                                    </form>
-                                  </div>
+                <div id="relay1">
+                  <form class="user" id="relay1-form" method="post" action="">
+                    <div class="form-group">
+                      Seuil de démarrage en %
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="seuil_demarrage_relay1"
+                        placeholder="%seuil_demarrage%"
+                      />
                     </div>
+                    <div class="form-group">
+                      Seuil d'arrêt en %
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="seuil_arret_relay1"
+                        placeholder="%seuil_arret%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Température de consigne (°C):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="temperature_relay1"
+                        placeholder="%temperature%"
+                      />
+                    </div>
+                    <input
+                      type="submit"
+                      value="Application des paramètres relay1"
+                      class="btn btn-primary btn-user btn-block"
+                    />
+                  </form>
                 </div>
+
+                <div id="relay2">
+                  <form class="user" id="relay2-form" method="post" action="">
+                    <div class="form-group">
+                      Seuil de démarrage en %
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="seuil_demarrage_relay2"
+                        placeholder="%seuil_demarrage%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Seuil d'arrêt en %
+                      <input
+                        type="text"
+                        class="form-control form-control-user"
+                        id="seuil_arret_relay2"
+                        placeholder="%seuil_arret%"
+                      />
+                    </div>
+                    <div class="form-group">
+                      Température de consigne (°C):
+                      <input
+                        type="number"
+                        step="1"
+                        class="form-control form-control-user"
+                        id="temperature_relay2"
+                        placeholder="%temperature%"
+                      />
+                    </div>
+                    <input
+                      type="submit"
+                      value="Application des paramètres relay2"
+                      class="btn btn-primary btn-user btn-block"
+                    />
+                  </form>
+                </div>
+              </div>
             </div>
-            <!-- Content Row -->
-<script>
-  $(document).ready(function() {
-    // Récupération des heures de démarrage et d'arrêt depuis le serveur
-    $.get("/getseuil?relay2", function(data) {
-      $("#seuil_demarrage_relay2").val(data.seuil_start);
-      $("#seuil_arret_relay2").val(data.seuil_stop);
-      $("#temperature_relay2").val(data.seuil_temp);
-      // Affichage de l'heure au format 2 digits
-      var heure = data.heure < 10 ? "0" + data.heure : data.heure;
-      var minute = data.minute < 10 ? "0" + data.minute : data.minute;
-      $("#heure").html( heure + ":" + minute );
-    });
-
-    $.get("/getseuil?relay1", function(data) {
-      $("#seuil_demarrage_relay1").val(data.seuil_start);
-      $("#seuil_arret_relay1").val(data.seuil_stop);
-      $("#temperature_relay1").val(data.seuil_temp);
-    });
-
-
-    // Envoi des données de formulaire au serveur lors de la soumission du formulaire
-
-    $("#relay1-form").submit(function(event) {
-      event.preventDefault();
-      var seuil_demarrage = $("#seuil_demarrage_relay1").val();
-      var seuil_arret = $("#seuil_arret_relay1").val();
-      var temperature = $("#temperature_relay1").val();
-      $.get("/setseuil?relay1", {"seuil_demarrage": seuil_demarrage, "seuil_arret": seuil_arret, "temperature": temperature});
-    });
-
-    $("#relay2-form").submit(function(event) {
-      event.preventDefault();
-      var seuil_demarrage = $("#seuil_demarrage_relay2").val();
-      var seuil_arret = $("#seuil_arret_relay2").val();
-      var temperature = $("#temperature_relay2").val();
-      $.get("/setseuil?relay2", {"seuil_demarrage": seuil_demarrage, "seuil_arret": seuil_arret, "temperature": temperature});
-    });
-
-
-  });
-</script>
-
+          </div>
+          <!-- Content Row -->
         </div>
+      </div>
     </div>
-</div>
-</div>
-</div>
-<!-- /.container-fluid -->
-</div>
-<!-- End of Main Content -->
-<!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- End of Main Content -->
+    <!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2022</span>
+          <span>https://github.com/xlyric/ - 2022</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- End of Content Wrapper -->
-</div>
-<!-- End of Page Wrapper -->
-<!-- Bootstrap core JavaScript-->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-<script></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- End of Page Wrapper -->
+
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+
+    <!-- Page script -->
+    <script>
+      $(document).ready(function () {
+        $("#tabs").tabs();
+
+        // Récupération des heures de démarrage et d'arrêt depuis le serveur
+        $.get("/getseuil?relay2", function (data) {
+          $("#seuil_demarrage_relay2").val(data.seuil_start);
+          $("#seuil_arret_relay2").val(data.seuil_stop);
+          $("#temperature_relay2").val(data.seuil_temp);
+          // Affichage de l'heure au format 2 digits
+          var heure = data.heure < 10 ? "0" + data.heure : data.heure;
+          var minute = data.minute < 10 ? "0" + data.minute : data.minute;
+          $("#heure").html(heure + ":" + minute);
+        });
+
+        $.get("/getseuil?relay1", function (data) {
+          $("#seuil_demarrage_relay1").val(data.seuil_start);
+          $("#seuil_arret_relay1").val(data.seuil_stop);
+          $("#temperature_relay1").val(data.seuil_temp);
+        });
+
+        // Envoi des données de formulaire au serveur lors de la soumission du formulaire
+
+        $("#relay1-form").submit(function (event) {
+          event.preventDefault();
+          var seuil_demarrage = $("#seuil_demarrage_relay1").val();
+          var seuil_arret = $("#seuil_arret_relay1").val();
+          var temperature = $("#temperature_relay1").val();
+          $.get("/setseuil?relay1", {
+            seuil_demarrage: seuil_demarrage,
+            seuil_arret: seuil_arret,
+            temperature: temperature,
+          });
+        });
+
+        $("#relay2-form").submit(function (event) {
+          event.preventDefault();
+          var seuil_demarrage = $("#seuil_demarrage_relay2").val();
+          var seuil_arret = $("#seuil_arret_relay2").val();
+          var temperature = $("#temperature_relay2").val();
+          $.get("/setseuil?relay2", {
+            seuil_demarrage: seuil_demarrage,
+            seuil_arret: seuil_arret,
+            temperature: temperature,
+          });
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/data/wifi.json
+++ b/data/wifi.json
@@ -1,1 +1,1 @@
-{"IP":"","mask":"","gateway":""}
+{ "IP": "", "mask": "", "gateway": "" }

--- a/data2/config-AP.html
+++ b/data2/config-AP.html
@@ -1,668 +1,720 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div><!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active" id="menu_mqtt" hidden >
-                    <a class="nav-link" href="/mqtt.html">
-                        <i class="fas fa-fw fa-book"></i>
-                        <span>Configuration MQTT</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/minuteur.html">
-                        <i class="fas fa-fw fa-moon"></i>
-                        <span>Minuteur d'appoint</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/log.html">
-                        <i class="fas fa-fw fa-info"></i>
-                        <span>Console logs</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/update">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>OTA</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
-                        <!-- Sidebar Toggle (Topbar) -->
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item dropdown no-arrow mx-1">
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
-						<p class="mb-4">Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur la flash après l'avoir appliquée.</p>
-                        <p class="mb-4">page rapide d'aide : <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a></p>
-
- 
-
-                        <!-- Content Row -->
-                        <div class="row">
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="state">%STATE%</span>(&#37;)
-                                                    <span id="power">%POWER%</span>(W)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="sigma">%SIGMA%</span>(°C)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Content Row -->
-                        <div class="row">
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Sauvegarder sur la flash</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="save">
-                                                        <a href="#">SAUVEGARDER</a>
-                                                    </span>
-                                                    <br>
-                                                    <span id="savemsg"></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-download fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Mise en route du dimmer</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span ><a href="#" id="ONOFF">Reading State</a></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="card position-relative">
-                                <div class="card-header py-3">
-                                    <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
-                                    <span id="saveform"></span>
-                                </div>
-                                <div class="card-body">
-                                    <div class="col-lg-12">
-                                            <form
-                                                class="user"
-                                                id="formulaire"
-                                                method="post"
-                                                action=""
-                                            >
-
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">Max Temp (°C)</div>
-                                                            <div class="col-sm-3">Trigger (&percnt;)</div>
-                                                            <div class="col-sm-3">Min Power (&percnt;)</div>
-                                                            <div class="col-sm-3">Max Power (&percnt;)</div>
-                                                                                                                    </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxtemp"
-                                                                    placeholder="%MAXTEMP%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="trigger"
-                                                                    placeholder="%TRIGGER%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="minpow"
-                                                                    placeholder="%MINPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxpow"
-                                                                    placeholder="%MAXPOW%"
-                                                                >
-                                                            </div>
-</div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) ">Charge 1 (W) ( dimmer )ℹ 
-                                                                <img height="40" alt="dimmer" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII=">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) ">Charge 2 (W) ( Jotta ) ℹ 
-                                                                <img height="40" alt="Jotta" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) ">Charge 3 (W) ( relay2 ) ℹ 
-                                                                <img height="40" alt="relay2"  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg==">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge1"
-                                                                    placeholder="%CHARGE1%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge2"
-                                                                    placeholder="%CHARGE2%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge3"
-                                                                    placeholder="%CHARGE3%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                               
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Child</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">Child Dimmer IP</div>
-                                                            <div class="col-sm-4">Child Dimmer Mode</div>
-                                                            <div class="col-sm-4" id="dimmer-url">
-                                                                <!-- L'url sera ajoutée ici -->
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="child"
-                                                                    placeholder="%CHILD%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <select id="delester" class="form-control form-control-user">
-                                                                    <option value="off">off</option>
-                                                                    <option value="delester">délester</option>
-                                                                    <option value="equal">égal</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Dimmer Name</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="dimmername"
-                                                                    placeholder="%DIMMERNAME%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative" id="menu_mqtt" hidden >
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary" >Pilote MQTT</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT state dimmer subscription (or : none)</a></div>
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT dimmer temp subscription (or : none)</a></div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribePV"
-                                                                    placeholder="%SUBSCRIBEPV%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribeTEMP"
-                                                                    placeholder="%SUBSCRIBETEMP%"
-                                                                >
-                                                            </div>
-                                                        </div>   
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Puissance de démarrage</div>
-                                                            <div class="col-sm-6">Etat au démarrage</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="startingpow"
-                                                                    placeholder="%STARTINGPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <select id="dimmer_on_off" class="form-control form-control-user">
-                                                                    <option value="1">on</option>
-                                                                    <option value="0">off</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                </div>
-                                            </div>
-                                            <br>
-                                            <div class="card position-relative" id="DALLAS-LOCAL">
-                                                <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
-                                                    <span id="saveform"></span>
-                                                </div>
-                                                <div class="card-body">
-                                                    <div class="form-group row">
-
-                                                        <div class="col-sm-6">
-                                                            Adresse sonde DALLAS maitre
-                                                            <br><br>
-                                                            <b>Sonde présentes: </b>
-                                                            <span id="dallas"></span>
-                                                        </div>
-                                                        <div class="col-sm-6">
-                                                            <input
-                                                                type="text"
-                                                                class="form-control form-control-user"
-                                                                id="DALLAS"
-                                                                placeholder="%DALLAS%"
-                                                            >
-                                                        </div>    
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!--  fin du formumaire et envoie -->
-                                    <input type="submit" value=" Application des paramètres" class="btn btn-primary btn-user btn-block">
-                                    
-                                    <hr>
-                                </div>
-                                <hr>
-                            </div>
-                        </div>
-
-                </div>
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span>
+            <span id="RSSI">RSSI : %RSSI% dBm</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active" id="menu_mqtt" hidden>
+          <a class="nav-link" href="/mqtt.html">
+            <i class="fas fa-fw fa-book"></i>
+            <span>Configuration MQTT</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/minuteur.html">
+            <i class="fas fa-fw fa-moon"></i>
+            <span>Minuteur d'appoint</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/log.html">
+            <i class="fas fa-fw fa-info"></i>
+            <span>Console logs</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/update">
+            <i class="fas fa-fw fa-download"></i>
+            <span>OTA</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
             </div>
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item dropdown no-arrow mx-1"></li>
+              <div class="topbar-divider d-none d-sm-block"></div>
+            </ul>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
+            <p class="mb-4">
+              Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur
+              la flash après l'avoir appliquée.
+            </p>
+            <p class="mb-4">
+              page rapide d'aide :
+              <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a>
+            </p>
 
             <!-- Content Row -->
-            <script type="text/javascript"> 
+            <div class="row">
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>(&#37;) <span id="power">%POWER%</span>(W)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>(°C)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Sauvegarder sur la flash
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="save">
+                            <a href="#">SAUVEGARDER</a>
+                          </span>
+                          <br />
+                          <span id="savemsg"></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-download fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Mise en route du dimmer
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span><a href="#" id="ONOFF">Reading State</a></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-6">
+              <div class="card position-relative">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
+                  <span id="saveform"></span>
+                </div>
+                <div class="card-body">
+                  <div class="col-lg-12">
+                    <form class="user" id="formulaire" method="post" action="">
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-3">Max Temp (°C)</div>
+                            <div class="col-sm-3">Trigger (&percnt;)</div>
+                            <div class="col-sm-3">Min Power (&percnt;)</div>
+                            <div class="col-sm-3">Max Power (&percnt;)</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxtemp"
+                                placeholder="%MAXTEMP%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="trigger"
+                                placeholder="%TRIGGER%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="minpow"
+                                placeholder="%MINPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxpow"
+                                placeholder="%MAXPOW%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) "
+                            >
+                              Charge 1 (W) ( dimmer )ℹ
+                              <img
+                                height="40"
+                                alt="dimmer"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII="
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) "
+                            >
+                              Charge 2 (W) ( Jotta ) ℹ
+                              <img
+                                height="40"
+                                alt="Jotta"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC"
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) "
+                            >
+                              Charge 3 (W) ( relay2 ) ℹ
+                              <img
+                                height="40"
+                                alt="relay2"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg=="
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge1"
+                                placeholder="%CHARGE1%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge2"
+                                placeholder="%CHARGE2%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge3"
+                                placeholder="%CHARGE3%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
 
-      //<!-- rafraichissement valeurs -->
-setInterval(function refreshsend( ) {
-        $.getJSON('/state', function(data) {
-          // Récupérer les données du JSON
-            var dimmer = data.dimmer;
-            var temperature = data.temperature;
-            var power= data.power;
-            var onoff = data.onoff;
-          document.getElementById("state").innerHTML = dimmer;
-          document.getElementById("sigma").innerHTML = temperature;
-          document.getElementById("power").innerHTML = power;
-          onoff = onoff ? "ON" : "OFF";
-          $("#ONOFF").text(onoff);
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Child</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-4">Child Dimmer IP</div>
+                            <div class="col-sm-4">Child Dimmer Mode</div>
+                            <div class="col-sm-4" id="dimmer-url">
+                              <!-- L'url sera ajoutée ici -->
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="child"
+                                placeholder="%CHILD%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <select id="delester" class="form-control form-control-user">
+                                <option value="off">off</option>
+                                <option value="delester">délester</option>
+                                <option value="equal">égal</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">Dimmer Name</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="dimmername"
+                                placeholder="%DIMMERNAME%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="menu_mqtt" hidden>
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Pilote MQTT</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT state dimmer subscription (or : none)</a
+                              >
+                            </div>
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT dimmer temp subscription (or : none)</a
+                              >
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribePV"
+                                placeholder="%SUBSCRIBEPV%"
+                              />
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribeTEMP"
+                                placeholder="%SUBSCRIBETEMP%"
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">Puissance de démarrage</div>
+                            <div class="col-sm-6">Etat au démarrage</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="startingpow"
+                                placeholder="%STARTINGPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <select id="dimmer_on_off" class="form-control form-control-user">
+                                <option value="1">on</option>
+                                <option value="0">off</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="DALLAS-LOCAL">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              Adresse sonde DALLAS maitre
+                              <br /><br />
+                              <b>Sonde présentes: </b>
+                              <span id="dallas"></span>
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="DALLAS"
+                                placeholder="%DALLAS%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                  <!--  fin du formumaire et envoie -->
+                  <input
+                    type="submit"
+                    value=" Application des paramètres"
+                    class="btn btn-primary btn-user btn-block"
+                  />
 
-          if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
-            } else {
-                    $('#alertBox').fadeOut();
-            }
-          
-          });
-}, 5000);
+                  <hr />
+                </div>
+                <hr />
+              </div>
+            </div>
+          </div>
+        </div>
 
+        <!-- Content Row -->
+        <script type="text/javascript">
+          //<!-- rafraichissement valeurs -->
+          setInterval(function refreshsend() {
+            $.getJSON("/state", function (data) {
+              // Récupérer les données du JSON
+              var dimmer = data.dimmer;
+              var temperature = data.temperature;
+              var power = data.power;
+              var onoff = data.onoff;
+              document.getElementById("state").innerHTML = dimmer;
+              document.getElementById("sigma").innerHTML = temperature;
+              document.getElementById("power").innerHTML = power;
+              onoff = onoff ? "ON" : "OFF";
+              $("#ONOFF").text(onoff);
 
-setInterval(function refreshsend( ) {
-        $.getJSON('/state_dallas', function(data) {
-          // affichage des dallas et les Température ( boucle sur les dallas )
-            var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
-            var dallasNumber; 
-        // Extraction des données des capteurs Dallas du JSON
-        for (var key in data) {
-            if (key.startsWith('dallas')) {
-                dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
-                var dallasTemperature = data[key];
-                var dallasAddressKey = 'addr' + dallasNumber;
-                var dallasAddress = data[dallasAddressKey];
-                dallasData[dallasNumber] = {
-                    temperature: dallasTemperature,
-                    address: dallasAddress
-                };
-            }
-        }
-                    // Affichage des données des capteurs Dallas dans la page HTML
-            var dallasHtml = '';
-            for ( dallasNumber in dallasData) {
-                dallasHtml += '<p>Dallas sensor ' + dallasNumber + ': ' + dallasData[dallasNumber].temperature + '°C <br>Address: ' + dallasData[dallasNumber].address + '</p>';
-            }
-            document.getElementById("dallas").innerHTML = dallasHtml;
-
-          });
-}, 5000);
-	
-function sendmode (mode) {
-
-		$.get( "/get", { send: 	mode } )
-		.done(function(data) {
-		document.getElementById("sendmode").innerHTML = "Request sent";
-		document.getElementById("sendmode2").innerHTML = "Request sent";
-		});
-
-
-}
-
-
-function save () {				  
-  		$.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		
-		});		
-
-
-}
-
-		
-		</script>
-           
-
-
-<script src="https://code.jquery.com/jquery-3.4.1.js">
-            </script>
-            <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-            </script>
-
-
-
-            <script>
-    $(function () {
-        $('[data-toggle="popover"]').popover()
-    })
-
-<!--- sauvegarde de la configuration --> 
-$( "#save" ).click(function() {
-
-    $.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		$( "#savemsg" ).text( "Configuration sauvegardée" ).show().fadeOut( 5000 );
-		});	
-});
-
-$( "#ONOFF" ).click(function() {
-  
-    $.get( "/onoff" )
-    .done(function(data) {
-        // si la data est 1 alors on affiche ON sinon OFF
-        if (data == 1) {
-            data = "ON";
-        } else {
-            data = "OFF";
-        }
-        $("#ONOFF").text(data);
-    });	
-});
-
-
-$( "#formulaire" ).submit(function() {
-
-	 var data = {'hostname':$('#hostname').val(), 'port':$('#port').val(), 'Publish':$('#Publish').val(),'maxtemp':$('#maxtemp').val(),  'startingpow':$('#startingpow').val(), 'minpow':$('#minpow').val(), 'maxpow':$('#maxpow').val(), 'child':$('#child').val(), 'SubscribePV':$('#SubscribePV').val(), 'SubscribeTEMP':$('#SubscribeTEMP').val(), 'mode':$('#delester').val() , 'charge1':$('#charge1').val() , 'charge2':$('#charge2').val() , 'charge3':$('#charge3').val(), 'DALLAS':$('#DALLAS').val(), 'dimmername':$('#dimmername').val(), 'trigger':$('#trigger').val()} 
-
-     $.ajax({
-            type: "GET",
-            data: data,
-            url: "get",
-
-            success: function(retour){
-                $( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-                     
-            }
-        });
-  return false;
-});
-
-
-
-        $(document).ready(function(){
-
-            function generateLink(dimmerValue) {
-                if (dimmerValue !== 'none') {
-                    var dimmerURL = "http://" + dimmerValue;
-                    $('#dimmer-url').html('<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + '</a>');
-                }
-            }
-
-
-        var recupconfig =  $.getJSON('/config', function(data) {
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-            var element = document.getElementById(key);
-            if (element) {
-                element.value = data[key];
-                if (element.type === 'checkbox') {
-                element.checked = data[key];
-                }
-            }
-            }
-        }
-
-            // Une fois la requête terminée
-            recupconfig.done(function() {
-                // Générer le lien avec la valeur initiale
-                var dimmerValue = $('#child').val();
-                generateLink(dimmerValue);
+              if (data.alerte && data.alerte.trim() != "") {
+                const alertContainer = document.getElementById("alertContainer");
+                alertContainer.innerHTML = "Alerte : " + data.alerte;
+                $("#alertBox").fadeIn();
+              } else {
+                $("#alertBox").fadeOut();
+              }
             });
+          }, 5000);
 
-            $('#child').on('input', function() {
+          setInterval(function refreshsend() {
+            $.getJSON("/state_dallas", function (data) {
+              // affichage des dallas et les Température ( boucle sur les dallas )
+              var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
+              var dallasNumber;
+              // Extraction des données des capteurs Dallas du JSON
+              for (var key in data) {
+                if (key.startsWith("dallas")) {
+                  dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
+                  var dallasTemperature = data[key];
+                  var dallasAddressKey = "addr" + dallasNumber;
+                  var dallasAddress = data[dallasAddressKey];
+                  dallasData[dallasNumber] = {
+                    temperature: dallasTemperature,
+                    address: dallasAddress,
+                  };
+                }
+              }
+              // Affichage des données des capteurs Dallas dans la page HTML
+              var dallasHtml = "";
+              for (dallasNumber in dallasData) {
+                dallasHtml +=
+                  "<p>Dallas sensor " +
+                  dallasNumber +
+                  ": " +
+                  dallasData[dallasNumber].temperature +
+                  "°C <br>Address: " +
+                  dallasData[dallasNumber].address +
+                  "</p>";
+              }
+              document.getElementById("dallas").innerHTML = dallasHtml;
+            });
+          }, 5000);
+
+          function sendmode(mode) {
+            $.get("/get", { send: mode }).done(function (data) {
+              document.getElementById("sendmode").innerHTML = "Request sent";
+              document.getElementById("sendmode2").innerHTML = "Request sent";
+            });
+          }
+
+          function save() {
+            $.get("/get", { save: "yes" }).done(function (data) {});
+          }
+        </script>
+
+        <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+        <script>
+          if (typeof jQuery == "undefined") {
+            document.write('<script src="/js/jquery.min.js"><\/script>');
+          }
+        </script>
+
+        <script>
+          $(function () {
+            $('[data-toggle="popover"]').popover();
+          });
+
+          <!--- sauvegarde de la configuration -->
+          $("#save").click(function () {
+            $.get("/get", { save: "yes" }).done(function (data) {
+              $("#savemsg").text("Configuration sauvegardée").show().fadeOut(5000);
+            });
+          });
+
+          $("#ONOFF").click(function () {
+            $.get("/onoff").done(function (data) {
+              // si la data est 1 alors on affiche ON sinon OFF
+              if (data == 1) {
+                data = "ON";
+              } else {
+                data = "OFF";
+              }
+              $("#ONOFF").text(data);
+            });
+          });
+
+          $("#formulaire").submit(function () {
+            var data = {
+              hostname: $("#hostname").val(),
+              port: $("#port").val(),
+              Publish: $("#Publish").val(),
+              maxtemp: $("#maxtemp").val(),
+              startingpow: $("#startingpow").val(),
+              minpow: $("#minpow").val(),
+              maxpow: $("#maxpow").val(),
+              child: $("#child").val(),
+              SubscribePV: $("#SubscribePV").val(),
+              SubscribeTEMP: $("#SubscribeTEMP").val(),
+              mode: $("#delester").val(),
+              charge1: $("#charge1").val(),
+              charge2: $("#charge2").val(),
+              charge3: $("#charge3").val(),
+              DALLAS: $("#DALLAS").val(),
+              dimmername: $("#dimmername").val(),
+              trigger: $("#trigger").val(),
+            };
+
+            $.ajax({
+              type: "GET",
+              data: data,
+              url: "get",
+
+              success: function (retour) {
+                $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+              },
+            });
+            return false;
+          });
+
+          $(document).ready(function () {
+            function generateLink(dimmerValue) {
+              if (dimmerValue !== "none") {
+                var dimmerURL = "http://" + dimmerValue;
+                $("#dimmer-url").html(
+                  '<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + "</a>"
+                );
+              }
+            }
+
+            var recupconfig = $.getJSON("/config", function (data) {
+              for (var key in data) {
+                if (data.hasOwnProperty(key)) {
+                  var element = document.getElementById(key);
+                  if (element) {
+                    element.value = data[key];
+                    if (element.type === "checkbox") {
+                      element.checked = data[key];
+                    }
+                  }
+                }
+              }
+
+              // Une fois la requête terminée
+              recupconfig.done(function () {
+                // Générer le lien avec la valeur initiale
+                var dimmerValue = $("#child").val();
+                generateLink(dimmerValue);
+              });
+
+              $("#child").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLink(dimmerValue);
+              });
             });
-
-
-        });
-
-});
-
-            </script>
-
-        </div>
+          });
+        </script>
+      </div>
     </div>
-</div>
-<!-- /.container-fluid -->
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- /.container-fluid -->
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2020</span>
+          <span>https://github.com/xlyric/ - 2020</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data2/config.html
+++ b/data2/config.html
@@ -1,668 +1,720 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div><!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active" id="menu_mqtt" >
-                    <a class="nav-link" href="/mqtt.html">
-                        <i class="fas fa-fw fa-book"></i>
-                        <span>Configuration MQTT</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/minuteur.html">
-                        <i class="fas fa-fw fa-moon"></i>
-                        <span>Minuteur d'appoint</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/log.html">
-                        <i class="fas fa-fw fa-info"></i>
-                        <span>Console logs</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/update">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>OTA</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
-                        <!-- Sidebar Toggle (Topbar) -->
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item dropdown no-arrow mx-1">
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
-						<p class="mb-4">Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur la flash après l'avoir appliquée.</p>
-                        <p class="mb-4">page rapide d'aide : <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a></p>
-
- 
-
-                        <!-- Content Row -->
-                        <div class="row">
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="state">%STATE%</span>(&#37;)
-                                                    <span id="power">%POWER%</span>(W)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Earnings (Monthly) Card Example -->
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="sigma">%SIGMA%</span>(°C)
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Content Row -->
-                        <div class="row">
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Sauvegarder sur la flash</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="save">
-                                                        <a href="#">SAUVEGARDER</a>
-                                                    </span>
-                                                    <br>
-                                                    <span id="savemsg"></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-download fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-info shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Mise en route du dimmer</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span ><a href="#" id="ONOFF">Reading State</a></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="card position-relative">
-                                <div class="card-header py-3">
-                                    <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
-                                    <span id="saveform"></span>
-                                </div>
-                                <div class="card-body">
-                                    <div class="col-lg-12">
-                                            <form
-                                                class="user"
-                                                id="formulaire"
-                                                method="post"
-                                                action=""
-                                            >
-
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">Max Temp (°C)</div>
-                                                            <div class="col-sm-3">Trigger (&percnt;)</div>
-                                                            <div class="col-sm-3">Min Power (&percnt;)</div>
-                                                            <div class="col-sm-3">Max Power (&percnt;)</div>
-                                                                                                                    </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxtemp"
-                                                                    placeholder="%MAXTEMP%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="trigger"
-                                                                    placeholder="%TRIGGER%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="minpow"
-                                                                    placeholder="%MINPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="maxpow"
-                                                                    placeholder="%MAXPOW%"
-                                                                >
-                                                            </div>
-</div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) ">Charge 1 (W) ( dimmer )ℹ 
-                                                                <img height="40" alt="dimmer" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII=">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) ">Charge 2 (W) ( Jotta ) ℹ 
-                                                                <img height="40" alt="Jotta" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC">
-                                                            </div>
-                                                            <div class="col-sm-4" data-toggle="popover" title="Aide" data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) ">Charge 3 (W) ( relay2 ) ℹ 
-                                                                <img height="40" alt="relay2"  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg==">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge1"
-                                                                    placeholder="%CHARGE1%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge2"
-                                                                    placeholder="%CHARGE2%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="charge3"
-                                                                    placeholder="%CHARGE3%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                               
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Child</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-4">Child Dimmer IP</div>
-                                                            <div class="col-sm-4">Child Dimmer Mode</div>
-                                                            <div class="col-sm-4" id="dimmer-url">
-                                                                <!-- L'url sera ajoutée ici -->
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="child"
-                                                                    placeholder="%CHILD%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-4">
-                                                                <select id="delester" class="form-control form-control-user">
-                                                                    <option value="off">off</option>
-                                                                    <option value="delester">délester</option>
-                                                                    <option value="equal">égal</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Dimmer Name</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="dimmername"
-                                                                    placeholder="%DIMMERNAME%"
-                                                                >
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <br>
-                                                <div class="card position-relative" id="menu_mqtt">
-                                                    <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary" >Pilote MQTT</h6>
-                                                        <span id="saveform"></span>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT state dimmer subscription (or : none)</a></div>
-                                                            <div class="col-sm-6"><a href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer" target="_blank" rel="noopener">MQTT dimmer temp subscription (or : none)</a></div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribePV"
-                                                                    placeholder="%SUBSCRIBEPV%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="text"
-                                                                    class="form-control form-control-user"
-                                                                    id="SubscribeTEMP"
-                                                                    placeholder="%SUBSCRIBETEMP%"
-                                                                >
-                                                            </div>
-                                                        </div>   
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">Puissance de démarrage</div>
-                                                            <div class="col-sm-6">Etat au démarrage</div>
-                                                        </div>
-                                                        <div class="form-group row">
-                                                            <div class="col-sm-6">
-                                                                <input
-                                                                    type="number"
-                                                                    step="1"
-                                                                    class="form-control form-control-user"
-                                                                    id="startingpow"
-                                                                    placeholder="%STARTINGPOW%"
-                                                                >
-                                                            </div>
-                                                            <div class="col-sm-3">
-                                                                <select id="dimmer_on_off" class="form-control form-control-user">
-                                                                    <option value="1">on</option>
-                                                                    <option value="0">off</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                </div>
-                                            </div>
-                                            <br>
-                                            <div class="card position-relative" id="DALLAS-LOCAL">
-                                                <div class="card-header py-3">
-                                                    <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
-                                                    <span id="saveform"></span>
-                                                </div>
-                                                <div class="card-body">
-                                                    <div class="form-group row">
-
-                                                        <div class="col-sm-6">
-                                                            Adresse sonde DALLAS maitre
-                                                            <br><br>
-                                                            <b>Sonde présentes: </b>
-                                                            <span id="dallas"></span>
-                                                        </div>
-                                                        <div class="col-sm-6">
-                                                            <input
-                                                                type="text"
-                                                                class="form-control form-control-user"
-                                                                id="DALLAS"
-                                                                placeholder="%DALLAS%"
-                                                            >
-                                                        </div>    
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!--  fin du formumaire et envoie -->
-                                    <input type="submit" value=" Application des paramètres" class="btn btn-primary btn-user btn-block">
-                                    
-                                    <hr>
-                                </div>
-                                <hr>
-                            </div>
-                        </div>
-
-                </div>
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span>
+            <span id="RSSI">RSSI : %RSSI% dBm</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active" id="menu_mqtt">
+          <a class="nav-link" href="/mqtt.html">
+            <i class="fas fa-fw fa-book"></i>
+            <span>Configuration MQTT</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/minuteur.html">
+            <i class="fas fa-fw fa-moon"></i>
+            <span>Minuteur d'appoint</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/log.html">
+            <i class="fas fa-fw fa-info"></i>
+            <span>Console logs</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/update">
+            <i class="fas fa-fw fa-download"></i>
+            <span>OTA</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
             </div>
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item dropdown no-arrow mx-1"></li>
+              <div class="topbar-divider d-none d-sm-block"></div>
+            </ul>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration</h1>
+            <p class="mb-4">
+              Page de configuration de votre pv dimmer, pensez à sauvegarder votre configuration sur
+              la flash après l'avoir appliquée.
+            </p>
+            <p class="mb-4">
+              page rapide d'aide :
+              <a href="https://wiki.apper-solaire.org/" target="_blank" rel="noopener"> ici </a>
+            </p>
 
             <!-- Content Row -->
-            <script type="text/javascript"> 
+            <div class="row">
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>(&#37;) <span id="power">%POWER%</span>(W)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>(°C)
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Sauvegarder sur la flash
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="save">
+                            <a href="#">SAUVEGARDER</a>
+                          </span>
+                          <br />
+                          <span id="savemsg"></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-download fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Mise en route du dimmer
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span><a href="#" id="ONOFF">Reading State</a></span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-6">
+              <div class="card position-relative">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Paramètres</h6>
+                  <span id="saveform"></span>
+                </div>
+                <div class="card-body">
+                  <div class="col-lg-12">
+                    <form class="user" id="formulaire" method="post" action="">
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Plage d'utilisation</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-3">Max Temp (°C)</div>
+                            <div class="col-sm-3">Trigger (&percnt;)</div>
+                            <div class="col-sm-3">Min Power (&percnt;)</div>
+                            <div class="col-sm-3">Max Power (&percnt;)</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxtemp"
+                                placeholder="%MAXTEMP%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="trigger"
+                                placeholder="%TRIGGER%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="minpow"
+                                placeholder="%MINPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="maxpow"
+                                placeholder="%MAXPOW%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Charges</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Robotdyn ou SSR 1 (GND et PWM pour le SSR + pontage pins synchro) "
+                            >
+                              Charge 1 (W) ( dimmer )ℹ
+                              <img
+                                height="40"
+                                alt="dimmer"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALoAAAC9CAYAAAAEC2dJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAt8SURBVHhe7Z0/6CVXFcdfhF1BFyRoxMJUqVIpRtPaiHXWIoUKaSNIrIO1pM4S0C7YWKQw1sHG1hhJqjSJjUIQAzEQA2YL3fN2Tn7n3Xf/zpw7c+493w/cffPmz9335/O+78x9M/N75IN/fvi/k0Ee//4vl6ljufP0j5apaz758++XqRyPLLc2ufP03WWKns/ry9R4vPbSrdP37nx4nv7mD353viX+8ccfn2+/cP4XRNkuOWEyR87MInkNED2BjuSMPdk9SU5A9Ai6kjN2ZPcmOQHRA/pIbgePkhMQXdBf8mNT3avkBERf2C/Jj5Hdg+RvfvK1c5PwPAwvPuCYcmW/YUdvSX7/3V8vU6fTrSd/dr51n+ioyX3gWvRjJe//RQrJb3Aruo0k7yc7JL/Epei2yhV92SH5Ne52Rm3W5Ho7pl4lp2NdmLvP3FumTqfX//DC+dZVotvd8dTJGu9JTgd18YFdDM9zI7pdyZltsqNcyeN61IWwITmzTnZIXsa16LYkZ9pkh+R1uBXdpuRtQPJ63JcuNimnOiRvA6KbJS07JG8HopvmWnZIvg6Ibp4b2SH5eiD6EFwmOyRvB6IDF0D0Ru6/+5tzk8Tm6VMeiQFpIPpG+gsONIDoG4Dk4wDRhwRlTCsQfQO3nnz+3I4BsrcA0YcGsjPPvng/e7kLiD48kJ0h2alJeB5Ez7DPsKEGkL0ERJ8GyJ4DomfgHU1OdQwnjgFfnYugq3ZRg+iVSMmPG2kpgVRPAdELhFLHJLclPmQnKNVlskP0Ckhkbikgu01wkdHpgewMyQ7RpwayMxB9eiA7AdFdANndXGQ0vCRdj+u69B5nf/S5N8636x+77T/u2xMkuiv8JjsSXRFOdO2hRu53e6Iz/pIdie4Sf8kO0d3iS3aIvjOvvXT79Ld7H3/e6D41TajUSTWJ/DOFEj4QKkY4P7cuU7NObyD6TrDg3/3yv5Y5D6H71GiZJvKwBW5ErexaHC04A9F3gCR/6oHMpWJBW/YQlv0aemTXjy6UNCetFaFTQPTOsOQM63TrW6+cW0hv2SXX4t/ILo/8K5Fa15L8EL0zUnLidiB4THbtmr0FkjMnecsHgGhdvxcQfUdI8hih7GEdr0VYn6cpFVlxLJcvEL0jLckcS/YtyJEWbkSsTudllzyUvVbeMLmtSQ/RnSBHXmppXT/EStlCQPRJYbFLgstllOypdWsSmsS2Wr5A9I48++Jny1SZz975+TJ1Ov3lP48tU1Z4WMbUJjTJbinNCYjembeEtFJmCc/nXcCWD8gexGv4sYDonQmlJanDJjkqzVMyX5Yy9FHMj8hYS3IGou+ATPUctN4Rac4y52r5S8aTHaLvAMn7xAtfyQqvKXm9sDfktqFl18vr63Za52j5IfqOSOFlo3lHJPl28sluCYh+ACS1bGMzhuwQHShAstsWHqIDRezKDtEHo8dJ3brYlB2iG0devcC+5Iw92c2KTj9gxJonwkt0jIWtut3sdV2+8fWvLlNx5Lhujw/AmrFofhxrtg2Rkn/02x+ebzX6PYbjryNjNtHpTY01ZvR0p2PVU8erj1mu5Dg+S4e8UleYnPJ+Sp6nvnR51s5bn8Z/pbz7zL3zrfxQ1VJKdHps4al1DP8yGpNc85vieI5J9+l2RknoWAupWUeT9+99nJScoGW0DjNHksc4JleHE33EkkUKXOKdn76qIjm9Trl2LPvLPtXOKM17/+X1l4ugcka7dImVK+FJ0uGhunTsiyTW71qoL41+9NinlBmydLH1RuUpSU6E81L7GVs5Pslj7JOzw426UBuFUNjU5S5CcrX8WkrfCrRctn3pL7tZ0cMXPmyzUfsh2EJOchkkqfX6QrL3E37YUZcZZe9F7rWy9zr2kd206GHKhM06Lceahzuk2uReL3uvpX66D5voKfp9+W2nVmb68UgLLkti2P9W1Hs3pxOdsCR7KG0oO90P52mddTRHeaeT7mZFb/k6lev+9dPHzo3GxFsbof01TtLGZI8JTmimOZF7PtrPtS/bZB/yByOrbxAnaOzx5Y5zYfh4l5Bcvylqt1nT9/G0/8g0xS+jVihJw+PqofApwZlWGXn9HLKvsP8x5G+TfbijF+WbaO2N6CVIa7/yNUoR9hVuY1tySZ3wUxymawUrovujLPuUoy7AG5TV+bweTvSar2XglbTw2BlVBKWLJS7LmSFLF7zhoMxlug+5M2oVJLpdsDMKXADRd4Z+NKJGp/zRuaR8H/QFou8Ey31xxYEHRSP9Skqt5QRq0A5qdEVStTRJXrycxjJIEJ4YTayt0Xm7kLCfUv+0PLVNSOtj3AskemdSkt/+9ivn9jlL3Gglu5RXNiIlaWp+jljfa/rpDUTvTCh5KHhM9q01u5Q8REopic1rJdW3BaYQXabIew/q4LWNBOuZSBdSC2Kyb2WtcFrPvddruBYkekdaklnKXqznM6wVjLbTSmOLqQ7RwRXW0lgDiC74jkhSuqptrI0KyStbCqs19lYgeiMtwjdd7uLtm/NH+fzVoyDZZ0t1iL6SWtmltFJmSWq+JiQvt1pmkh2ib6BG9jDVSeqwSeiD0fJNEKJVemzpx+IHZELR9/2ht0b2llJki+QSLdlmSfVJE32d7HQ9GIYuxh+2FCXZSd4nfnH9076EPgyldWrhNI5J2iLumlTn/rW+WbSYuHTRT/YtshMkMjWSWjaap5XkjJRdNkJTwt79azHFQV3yBX7v5X+fp2+ov/4HJXrNX7xISd3rzyRaFmgUphN9K7V9xWSH6HaZSnRNaqQKZWfRH33ujWyZ0wpE384UNfpRAmyt2cF+4MQLBVhqmeiMRrIj0beDH4wUQLLbB6IrAdltg9JFES4xuHR5+yevXgxu0ph5LXJcHaXLdpDonZEpQidU1DagC0TvQFjGmPzKdAZE70RM9hGEpzKJS6UStetZAKJ3RB4kxpDsdH6obJrUiBpbHm6X60cu4+nUulaA6DvzxYjYmrKXdlhjQvI82la2GC3rWgKi70hM8l7kElaKKcUNCee1rGsNiG4E7RKmhRpJc5KPAESfkJSMYcrnUn82ILoR/hucO6pBTORRE3krEH1HSjJjvL0fEH1nQtnpvpynJXuY3J7KlBgQ/QBY7lB6BsmuD0SfHJnkYcq31Ouj1/YQfWJq5Wwpa0YtgXCYriIsgXb6bek3l+hMrP/Udi3rWgKiKxKTQIMt/dZuK2VlUtu0rGsFiK6IRdHBQyC6IrGk0wSirwc7o8AFSHTgAiQ6cAFEBy6A6MAFEB24AKJvgIYTew8pAh1cjrrUyFkasw77wBi3bZDoCVrSGpLbx3Wi5wSVkqfWo3Ug+Rgg0RPUCAzJxwGiZ2CRa0sYYBeIDlyAGr1Abt3UMjk/921Q842xZ98hqW1T29U8ttL/2Quzif73P/1qmTqWGmFS1Gyzpl+itB0tr1knRWnZmm2Pkpwwm+hEr1TnN6L2hU+tX5rPxP6flnXksp59M3L7lm1r/t+jQI3emZo3e60QPfouSS4JxZasfU69gOgd6SEi07NvhkSOtRLWJCcgOnCBadEt7JBygllMqZ7Q861po4BEBy6A6Blq6lEwBuZFt1C+jPQVvRV+rrkPOe+UjhQESPQI8k30JHlITGQ5DzX6ILDQYWO8Si6f9yyvzRCiH1G+WH0jax6Xxjq0PLVOTf/WMH0IgAQXNAJbGKZ0sXKQFxgT7IwCFwwlOlIdrAWJDlwwnOhIdbCGIRMdsoNWULoAFwwrOlIdtDB0okN2UAtKF+CC4UVHqoMapkh0yA5KTFO6QHaQY6oaHbKDFNPtjEJ2EGOY49HXgGPYATNdokuQ7oCZWnQCsgNi6tIlBKWMX1yJzkB4f0xfusRAOeMPl4kuQbr7wL3oEkg/LxA9AaSfC4heCcQfG4gOXOBy1AX4A6IDF0B04AKIDhxwOv0f5ngmv/Jp6HgAAAAASUVORK5CYII="
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Jotta ou SSR2 (pontage pins synchro) "
+                            >
+                              Charge 2 (W) ( Jotta ) ℹ
+                              <img
+                                height="40"
+                                alt="Jotta"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJwAAABpCAYAAADP50rnAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAVHSURBVHhe7Zy9btRAEMcTRGiIhCh4AhpSUYDyCPRQ0FISJETPE9AjJGhpKaDnESIoqFJBixBICAkaUkDG8SiTvf3+mNtb/3/S6nxee87n/WXW3j1n++KNg39bHo6PXs5LfbCz92heGo/d/bvT6+/Dd9PriFyYXwFQ4STDPTzJcNvz21U4w42cWXphQRnO26sCUA3RpZJ0EA+0xXINB/FAOzw3DRAP1Ad3qUCVBOGQ7UA5iRkO3SwoI7NLhXggj8JrOIgH0phnGtwcH72alwAoB3epQJVghivDPUcLVsGvRYrBNR44j1KXCvHAKcrXcBBv6azppoHFg3xLo4O7VIi3JDoQjoF4S6Aj4RgWD/KNSIfCSSDeaDQe+K1N2kCy7RFH+TCQ6wEhud73mGTsg0WuGOb+cuDXdWyE75gI3z6xx9yKzjOcCWe88N+Iq1FCjZVCaSyNYyRqxythw4STuOWTJ5j+orkwZgPENIiMI2OlYNs/9Nm2elsc2zobMd+1JRssnMQunnny+b2tUbQbIiTGqAwiHGMXT1KroTlObVF/vr4zvdY6Tj6+XgQfTDiTsIBEK3lKqX1cPXzPwYU7hU6wWVz46jQJHWcMcv8a8WqwCOF29g7mJcn5zJfa5XDj1eyquDu10YMsNRhaOPnzeLt0zKl8NeUJ4ROIjkOWUmzx1iXwkMJJuUg6Low747mv96iBZMnBtn8rATgex++FYTOcK6P5M51Z77/hKG1M2/5XH7yfl85Yd1aqyYZNbfVAu+c08EwDsMBdLxeQAoQrBgKmAOGqAwF9QLjmQEAJhFPHFHBZEkK4LjDFG1fCoYdFUv8RT2iMjkiNmYP7OM4PyaSMy/UyAIwMl0iMlO3gTMhl81hEhluvJPHs7t+bXn8fvp1ea3B2DpDhgCpmdjSLDpja6ogWGa4deVN8yHAgEzNDxhUIB1SBcEAVCAdUgXBAFQgHVIFwQJWhhaNRdo25z57p7RwgwwFVMJeawJtnl+alM+4//TsvlUGxb1/+Pi1/+HOtWtza56AUCBeBlMFGriCt4kp6Ew5daoAvz395pSCo3pb9fIRkI6iePn8kIJyHlMZOkS5GNslI0kE4BzZ5dm6+WCmSWInM7UJxidQM2ivVhKNrBb5eiMW3T068mtiksGGuD4lh1sfGTcmIPYMM54B/UEO4pLBRU4xUmTcBCGdBNmzMLXyukCn7jUJT4bhbtHWP8r1Z76tjeL0soH+aCWcToIYUvcolu+BYjj89npeWQxPhpBA04CgHHblOrjO38dUxvN5WV4o52Po3IIasD0lHg7m51Jp9WCfZwsVkGSlDCzFa8jFSDFPG0H6mNL4sN2IGzBJuXV2aLTu2wpbluMj3EpItJgtRluMumArFkXLRsilbSWbsiaIuVVs8Fk3rc13ZyhSNie3yaDszNotHRcpI1JhT7YXsyXtXo4ekMLOT3E7WmfvHyOaKba5P5XNgaik2s5nQ8MutwLhdbmym1jmoRdWbhtIv5ZJPso4Td/3JlanhzaxE76kuVwjaj2NL+LNKYvcKfp40OENnOABCQDigCoQDqkA4oAqEA6pAOKAKhAOqQDigCoQDqkC4hUMzEWbxEbONDwgHVnBJVSIaA+HABM21cmGkYDVkIyAcWKHlRD+EA1GY2S8XCAessFy1ulIGwgFVIBywwpmt9vUchAOqQDiwQu3rNgmEAxMkGRemxfDIIh6iAW55XOcotH2ujBBuIbTIVjmgSwWqDJ3hQH8gwwFVtr9++4EMB9RAhgOqQDigCoQDqkA4oAqEA6pAOKAKhAOKbG39B/7N2dFj5M6PAAAAAElFTkSuQmCC"
+                              />
+                            </div>
+                            <div
+                              class="col-sm-4"
+                              data-toggle="popover"
+                              title="Aide"
+                              data-content="Charge branchée sur la sortie Relay 2 ou SSR 3 (pontage pins synchro) "
+                            >
+                              Charge 3 (W) ( relay2 ) ℹ
+                              <img
+                                height="40"
+                                alt="relay2"
+                                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAABqCAYAAAAr3BQjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAg2SURBVHhe7d2/jhxFEAbws/FlBoTwAwARRkCE7w38ABAQAiFImJwnIMdIpJiQAB6ANzgTAYIMeACQBVx2INjyTWvLddXd1f+7976ftPLc7EzP7F59U7Oze+trN26//99Ropsnb21TF85Ov96mBmKPQu4fmWIf4Uq4vv0LAJUgVACVHUaokk9gAdpBpwKoDKECqAyhAqhs/VDh9RRMBp0KoDKECqAyhAqgsrVDhddTMCF0KoDKECqAyhAqgMrWDRVeT8Gk0KkAKisPFToGwBPW7FQIMkysLFQoboBL1utUCDJMLj9UKG4A1ZqvqQAmlvcVZXfEV5Q91L/+6/ynz7epC8evfLBNXaD75TzC58sxyPHty+tw8ivKHj24u01diK1Pzn/e7YNnObrPJ7SOZbuc207qmHz/Qtu0LgdpmnUqLQx8npvWliO++YSKgRdEiAwUia3v7tOWiW03Z50cvu3I+SXLQZ4moeKBoI7Du1EoLCF0JC05mrr1+Rg5haSNw+fx+VLq9txYlvX4MnI/+H3W5SBf09dUPEzaaZ6TEjReCLlFwAuptd6Fyh9b6HFal4N01UPlAqKFqFawanCFJIve/ey7v1SN8eQ+hlgDg2DV0/3qnwxWKGiHJLdoa4RbjuHbFwSrji6hoi7Eb5ILVu9uJfkKN7egUzqKVUm4oI/unSpmdLCcmsVLY/Hxcsfm6+UEVXYsaKN6qLSuQ/Nip3m9TwNdYa1wylOyj/Q4LSGyLgdxTTsVD5alA10Kludt6dJAaMXDx5Q3klpwvvGc1PE4Po5kHbdk+xDWJFQ8HBQm2bVyUBG4Ww5t/VBxtpK7zdh6MrD8sfL7rMtBvmadSguPJVCmZXa//NICqFFAsTF6F6m2vZJ5kKfpZ/+KFHwKHv89KYw03dW/x/BnJbCwOUMFsLD5QoUuBYtDpwKobK5QoUvBAZji6p/ljWEoh8vmfQzvVAhUP+5NXmhreKd64tMWiUdS3ycBYu9TjfwEQe62S/aZh2nEY75qcKECoDKECqCysad/uy1rpyZ8HuTTnk+c/rWHTgVQ2bhOtW011Klyj6pX/QO18vlDp+prTKdKjjHAOnD6B1BZ/1ChS8GB6xsqBAqugH4XKjxbwYWK+lIvVPD7Ndo4Glou9XcXWj71Pm3/rPtRE15TQZRWrFJp8Ya2Ie/TlvWtb9n32vqECqd9S6BgyJvGulxMrOD5uG5Zvo623dJ9qqF9qAYF6sd3vnh8a+GrT463qbpo3FZjr0oLFvEFagZtX1MZRtaeKDcv50miojx5+o/tp73Tv58/evvj8+2ndL3HJS98+Mw2lUY+f7Fi5PdrtHEcOV7K744vG1uPbztlbGJZvqZ2napzh6Li/O2zv7wFSvPp/lTWcWm5VKFxSe64NbUqyJTwkdz96B0o0iZUAwIVKk4uNVjWca3LOdb9oHFzg0WFy4/YMVSAliJ0y9Uo2NR9tEgNbG1TXf3LfYJlQT/12qeXbpy1SGXhx8a1BkVuPzZuamBLtS7G0O+4NGCjA0Xqh2pAl+JkQTp8fk6RWsa14tu3jpvTrUq6iVuvtMhD3P6V7Cc3Q6BI3VAVBqrWk2sRK9KcIiatxh1JBot+1m5c7P6QlGUdvg7fZs5YpZJDRd8p8ejB3e0nZhco+SD4A+O3VnK6Rg2ttsvH7X0KSFoe4LSxLdvTlonVVMua0yRfUndf1PLcu98+/pe4jwC5nXcPPPRgtGXkPMuTTEd+V3Cx4v73h4+2qfilcD4uCY3dalzCx7ZeYrc879BOswsVPBj8FkLrhAoihhfgrFLe05JhhTU0C5ULEA9KSWB8ZJH6giXnx4q71biSb1wpdVwYp1moJB4oX8eydDONPIrLQpU/W4/6I8fl86zjSrnPJ5TpFiqudsfSjuKuMGXBUoFaj/q0nBYAbVwyelyYw1SvqUrQi/jYET0lUI4WAInuT/2cXqtxYby0UHV+YzcVFaovXK9++V72Ed83riv60nE1NHbuuDCW/ZI6W8p1IXdZnS6py9dMvFNxcr5cj/jWTbHSX//ePHlzm9o7O/1mm0pneY6hHVun8sSO3gSmW+iXRvfxG8ChC4eKwqQEir/xy/FAhY6IOFpCb/Sme+hWk//0z9OdiDy1Kjmt0rqcm1cSPpz+XX4+yVU6oFFY7tz8ffspzJX7d2e3il/L6p0qECiA2VGYfr3/pzlQ3Bu7dX7ZrVvSvS6HCoGCReWGSSv5knDtQ0UjI1CwqJRTvRQUrtRgXYQKYYKFWQJ14/X73tvx7haSGqzrCBSsLBYoF5wYClYoXCnBCl9SB5hYKFDWMEmhcFmDhVDBskKBKhUKVgxCBUvydYwagXJ8wYp1K4QKlqR1qZqBcrRgxboVQgXLsV4waCm0DwgVLKdXl3JSuxVCBUuZoUs5vn1BqGB5LbuU47toobl24+WM/0qn06fUocwhfkqduoM8/esRKnL+/b1tau+le89uU3voVLAU33tTM5kyVFfpb35awXM4zpSnfzXs93H/8Er+8K+l2n+kKB3S6R/9aYeE07+u8Glh6G+qTgXtoVPlW6ZT4dy/n0N4rh+e3dqmxqPvs9AM71SttH6dUtNK+zraTJfUfV8Sg0vqsBStiP9RTstq0079fN+6hFABVIZQwXK011Utu5XWpXyvpwhCBcvxnXa1CJYWKBL6wk2ECpY08ipgqEsRhAqWRJ3CdxpYo2NRh/Kd9oW6FEGoYFmh4vadtlmE1o0FiiBUsLQXlU80OL5u4xNbXvv0hAahguXJYMlPM7iwyND45musgSIIFRyEUMeSLCHiUgJ1dHR09D9uCxzvnr5M5AAAAABJRU5ErkJggg=="
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge1"
+                                placeholder="%CHARGE1%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge2"
+                                placeholder="%CHARGE2%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="charge3"
+                                placeholder="%CHARGE3%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
 
-      //<!-- rafraichissement valeurs -->
-setInterval(function refreshsend( ) {
-        $.getJSON('/state', function(data) {
-          // Récupérer les données du JSON
-            var dimmer = data.dimmer;
-            var temperature = data.temperature;
-            var power= data.power;
-            var onoff = data.onoff;
-          document.getElementById("state").innerHTML = dimmer;
-          document.getElementById("sigma").innerHTML = temperature;
-          document.getElementById("power").innerHTML = power;
-          onoff = onoff ? "ON" : "OFF";
-          $("#ONOFF").text(onoff);
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Child</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-4">Child Dimmer IP</div>
+                            <div class="col-sm-4">Child Dimmer Mode</div>
+                            <div class="col-sm-4" id="dimmer-url">
+                              <!-- L'url sera ajoutée ici -->
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="child"
+                                placeholder="%CHILD%"
+                              />
+                            </div>
+                            <div class="col-sm-4">
+                              <select id="delester" class="form-control form-control-user">
+                                <option value="off">off</option>
+                                <option value="delester">délester</option>
+                                <option value="equal">égal</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Hostname</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">Dimmer Name</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="dimmername"
+                                placeholder="%DIMMERNAME%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="menu_mqtt">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Pilote MQTT</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT state dimmer subscription (or : none)</a
+                              >
+                            </div>
+                            <div class="col-sm-6">
+                              <a
+                                href="https://wiki.apper-solaire.org/index.php?page=adv-dimmer"
+                                target="_blank"
+                                rel="noopener"
+                                >MQTT dimmer temp subscription (or : none)</a
+                              >
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribePV"
+                                placeholder="%SUBSCRIBEPV%"
+                              />
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="SubscribeTEMP"
+                                placeholder="%SUBSCRIBETEMP%"
+                              />
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">Puissance de démarrage</div>
+                            <div class="col-sm-6">Etat au démarrage</div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              <input
+                                type="number"
+                                step="1"
+                                class="form-control form-control-user"
+                                id="startingpow"
+                                placeholder="%STARTINGPOW%"
+                              />
+                            </div>
+                            <div class="col-sm-3">
+                              <select id="dimmer_on_off" class="form-control form-control-user">
+                                <option value="1">on</option>
+                                <option value="0">off</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <br />
+                      <div class="card position-relative" id="DALLAS-LOCAL">
+                        <div class="card-header py-3">
+                          <h6 class="m-0 font-weight-bold text-primary">Dallas Local</h6>
+                          <span id="saveform"></span>
+                        </div>
+                        <div class="card-body">
+                          <div class="form-group row">
+                            <div class="col-sm-6">
+                              Adresse sonde DALLAS maitre
+                              <br /><br />
+                              <b>Sonde présentes: </b>
+                              <span id="dallas"></span>
+                            </div>
+                            <div class="col-sm-6">
+                              <input
+                                type="text"
+                                class="form-control form-control-user"
+                                id="DALLAS"
+                                placeholder="%DALLAS%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                  <!--  fin du formumaire et envoie -->
+                  <input
+                    type="submit"
+                    value=" Application des paramètres"
+                    class="btn btn-primary btn-user btn-block"
+                  />
 
-          if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
-            } else {
-                    $('#alertBox').fadeOut();
-            }
-          
-          });
-}, 5000);
+                  <hr />
+                </div>
+                <hr />
+              </div>
+            </div>
+          </div>
+        </div>
 
+        <!-- Content Row -->
+        <script type="text/javascript">
+          //<!-- rafraichissement valeurs -->
+          setInterval(function refreshsend() {
+            $.getJSON("/state", function (data) {
+              // Récupérer les données du JSON
+              var dimmer = data.dimmer;
+              var temperature = data.temperature;
+              var power = data.power;
+              var onoff = data.onoff;
+              document.getElementById("state").innerHTML = dimmer;
+              document.getElementById("sigma").innerHTML = temperature;
+              document.getElementById("power").innerHTML = power;
+              onoff = onoff ? "ON" : "OFF";
+              $("#ONOFF").text(onoff);
 
-setInterval(function refreshsend( ) {
-        $.getJSON('/state_dallas', function(data) {
-          // affichage des dallas et les Température ( boucle sur les dallas )
-            var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
-            var dallasNumber; 
-        // Extraction des données des capteurs Dallas du JSON
-        for (var key in data) {
-            if (key.startsWith('dallas')) {
-                dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
-                var dallasTemperature = data[key];
-                var dallasAddressKey = 'addr' + dallasNumber;
-                var dallasAddress = data[dallasAddressKey];
-                dallasData[dallasNumber] = {
-                    temperature: dallasTemperature,
-                    address: dallasAddress
-                };
-            }
-        }
-                    // Affichage des données des capteurs Dallas dans la page HTML
-            var dallasHtml = '';
-            for ( dallasNumber in dallasData) {
-                dallasHtml += '<p>Dallas sensor ' + dallasNumber + ': ' + dallasData[dallasNumber].temperature + '°C <br>Address: ' + dallasData[dallasNumber].address + '</p>';
-            }
-            document.getElementById("dallas").innerHTML = dallasHtml;
-
-          });
-}, 5000);
-	
-function sendmode (mode) {
-
-		$.get( "/get", { send: 	mode } )
-		.done(function(data) {
-		document.getElementById("sendmode").innerHTML = "Request sent";
-		document.getElementById("sendmode2").innerHTML = "Request sent";
-		});
-
-
-}
-
-
-function save () {				  
-  		$.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		
-		});		
-
-
-}
-
-		
-		</script>
-           
-
-
-<script src="https://code.jquery.com/jquery-3.4.1.js">
-            </script>
-            <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-            </script>
-
-
-
-            <script>
-    $(function () {
-        $('[data-toggle="popover"]').popover()
-    })
-
-<!--- sauvegarde de la configuration --> 
-$( "#save" ).click(function() {
-
-    $.get( "/get", { save: "yes" } )
-		.done(function(data) {
-		$( "#savemsg" ).text( "Configuration sauvegardée" ).show().fadeOut( 5000 );
-		});	
-});
-
-$( "#ONOFF" ).click(function() {
-  
-    $.get( "/onoff" )
-    .done(function(data) {
-        // si la data est 1 alors on affiche ON sinon OFF
-        if (data == 1) {
-            data = "ON";
-        } else {
-            data = "OFF";
-        }
-        $("#ONOFF").text(data);
-    });	
-});
-
-
-$( "#formulaire" ).submit(function() {
-
-	 var data = {'hostname':$('#hostname').val(), 'port':$('#port').val(), 'Publish':$('#Publish').val(),'maxtemp':$('#maxtemp').val(),  'startingpow':$('#startingpow').val(), 'minpow':$('#minpow').val(), 'maxpow':$('#maxpow').val(), 'child':$('#child').val(), 'SubscribePV':$('#SubscribePV').val(), 'SubscribeTEMP':$('#SubscribeTEMP').val(), 'mode':$('#delester').val() , 'charge1':$('#charge1').val() , 'charge2':$('#charge2').val() , 'charge3':$('#charge3').val(), 'DALLAS':$('#DALLAS').val(), 'dimmername':$('#dimmername').val(), 'trigger':$('#trigger').val()} 
-
-     $.ajax({
-            type: "GET",
-            data: data,
-            url: "get",
-
-            success: function(retour){
-                $( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-                     
-            }
-        });
-  return false;
-});
-
-
-
-        $(document).ready(function(){
-
-            function generateLink(dimmerValue) {
-                if (dimmerValue !== 'none') {
-                    var dimmerURL = "http://" + dimmerValue;
-                    $('#dimmer-url').html('<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + '</a>');
-                }
-            }
-
-
-        var recupconfig =  $.getJSON('/config', function(data) {
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-            var element = document.getElementById(key);
-            if (element) {
-                element.value = data[key];
-                if (element.type === 'checkbox') {
-                element.checked = data[key];
-                }
-            }
-            }
-        }
-
-            // Une fois la requête terminée
-            recupconfig.done(function() {
-                // Générer le lien avec la valeur initiale
-                var dimmerValue = $('#child').val();
-                generateLink(dimmerValue);
+              if (data.alerte && data.alerte.trim() != "") {
+                const alertContainer = document.getElementById("alertContainer");
+                alertContainer.innerHTML = "Alerte : " + data.alerte;
+                $("#alertBox").fadeIn();
+              } else {
+                $("#alertBox").fadeOut();
+              }
             });
+          }, 5000);
 
-            $('#child').on('input', function() {
+          setInterval(function refreshsend() {
+            $.getJSON("/state_dallas", function (data) {
+              // affichage des dallas et les Température ( boucle sur les dallas )
+              var dallasData = {}; // Objet pour stocker les données des capteurs Dallas
+              var dallasNumber;
+              // Extraction des données des capteurs Dallas du JSON
+              for (var key in data) {
+                if (key.startsWith("dallas")) {
+                  dallasNumber = key.substring(6); // Récupérer le numéro du capteur Dallas
+                  var dallasTemperature = data[key];
+                  var dallasAddressKey = "addr" + dallasNumber;
+                  var dallasAddress = data[dallasAddressKey];
+                  dallasData[dallasNumber] = {
+                    temperature: dallasTemperature,
+                    address: dallasAddress,
+                  };
+                }
+              }
+              // Affichage des données des capteurs Dallas dans la page HTML
+              var dallasHtml = "";
+              for (dallasNumber in dallasData) {
+                dallasHtml +=
+                  "<p>Dallas sensor " +
+                  dallasNumber +
+                  ": " +
+                  dallasData[dallasNumber].temperature +
+                  "°C <br>Address: " +
+                  dallasData[dallasNumber].address +
+                  "</p>";
+              }
+              document.getElementById("dallas").innerHTML = dallasHtml;
+            });
+          }, 5000);
+
+          function sendmode(mode) {
+            $.get("/get", { send: mode }).done(function (data) {
+              document.getElementById("sendmode").innerHTML = "Request sent";
+              document.getElementById("sendmode2").innerHTML = "Request sent";
+            });
+          }
+
+          function save() {
+            $.get("/get", { save: "yes" }).done(function (data) {});
+          }
+        </script>
+
+        <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+        <script>
+          if (typeof jQuery == "undefined") {
+            document.write('<script src="/js/jquery.min.js"><\/script>');
+          }
+        </script>
+
+        <script>
+          $(function () {
+            $('[data-toggle="popover"]').popover();
+          });
+
+          <!--- sauvegarde de la configuration -->
+          $("#save").click(function () {
+            $.get("/get", { save: "yes" }).done(function (data) {
+              $("#savemsg").text("Configuration sauvegardée").show().fadeOut(5000);
+            });
+          });
+
+          $("#ONOFF").click(function () {
+            $.get("/onoff").done(function (data) {
+              // si la data est 1 alors on affiche ON sinon OFF
+              if (data == 1) {
+                data = "ON";
+              } else {
+                data = "OFF";
+              }
+              $("#ONOFF").text(data);
+            });
+          });
+
+          $("#formulaire").submit(function () {
+            var data = {
+              hostname: $("#hostname").val(),
+              port: $("#port").val(),
+              Publish: $("#Publish").val(),
+              maxtemp: $("#maxtemp").val(),
+              startingpow: $("#startingpow").val(),
+              minpow: $("#minpow").val(),
+              maxpow: $("#maxpow").val(),
+              child: $("#child").val(),
+              SubscribePV: $("#SubscribePV").val(),
+              SubscribeTEMP: $("#SubscribeTEMP").val(),
+              mode: $("#delester").val(),
+              charge1: $("#charge1").val(),
+              charge2: $("#charge2").val(),
+              charge3: $("#charge3").val(),
+              DALLAS: $("#DALLAS").val(),
+              dimmername: $("#dimmername").val(),
+              trigger: $("#trigger").val(),
+            };
+
+            $.ajax({
+              type: "GET",
+              data: data,
+              url: "get",
+
+              success: function (retour) {
+                $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+              },
+            });
+            return false;
+          });
+
+          $(document).ready(function () {
+            function generateLink(dimmerValue) {
+              if (dimmerValue !== "none") {
+                var dimmerURL = "http://" + dimmerValue;
+                $("#dimmer-url").html(
+                  '<a href="' + dimmerURL + '" target="_blank" rel="noopener">' + dimmerURL + "</a>"
+                );
+              }
+            }
+
+            var recupconfig = $.getJSON("/config", function (data) {
+              for (var key in data) {
+                if (data.hasOwnProperty(key)) {
+                  var element = document.getElementById(key);
+                  if (element) {
+                    element.value = data[key];
+                    if (element.type === "checkbox") {
+                      element.checked = data[key];
+                    }
+                  }
+                }
+              }
+
+              // Une fois la requête terminée
+              recupconfig.done(function () {
+                // Générer le lien avec la valeur initiale
+                var dimmerValue = $("#child").val();
+                generateLink(dimmerValue);
+              });
+
+              $("#child").on("input", function () {
                 var dimmerValue = $(this).val();
                 generateLink(dimmerValue);
+              });
             });
-
-
-        });
-
-});
-
-            </script>
-
-        </div>
+          });
+        </script>
+      </div>
     </div>
-</div>
-<!-- /.container-fluid -->
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- /.container-fluid -->
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2020</span>
+          <span>https://github.com/xlyric/ - 2020</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data2/index-AP.html
+++ b/data2/index-AP.html
@@ -1,185 +1,170 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
+
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span>
+            <span id="RSSI">RSSI : %RSSI% dBm</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <div class="topbar-divider d-none d-sm-block"></div>
             </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-    <div id="content-wrapper" class="d-flex flex-column">
+          </nav>
+          <!-- End of Topbar -->
 
-      <!-- Main Content -->
-      <div id="content">
-
-        <!-- Topbar -->
-        <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-
-          <!-- Sidebar Toggle (Topbar) -->
-
-
-
-          <!-- Topbar Navbar -->
-          <ul class="navbar-nav ml-auto">
-            <div class="topbar-divider d-none d-sm-block"></div>
-          </ul>
-
-        </nav>
-        <!-- End of Topbar -->
-
-        <!-- Begin Page Content -->
-        <div class="container-fluid">
-
-          <!-- Page Heading -->
-          <div class="d-sm-flex align-items-center justify-content-between mb-4">
-            <h1 class="h3 mb-0 text-gray-800">Dashboard-AP</h1>
-           
-          </div>
-
-          <!-- Content Row -->
-
-          <div class="row">
-
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-primary shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Puissance</div>
-                      <div class="h5 mb-0 font-weight-bold text-gray-800"><span id="state">%STATE%</span></div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                    </div>
-                  </div>
-                </div>
-              </div>
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <div class="d-sm-flex align-items-center justify-content-between mb-4">
+              <h1 class="h3 mb-0 text-gray-800">Dashboard-AP</h1>
             </div>
 
-            <!-- Earnings (Monthly) Card Example -->
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-info shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Température</div>
-                      <div class="h5 mb-0 font-weight-bold text-gray-800"><span id="sigma">%SIGMA%</span></div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+            <!-- Content Row -->
+
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Puissance
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="state">%STATE%</span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-calendar fa-2x text-gray-300"></i>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>  
-         
 
-
-				
-				
-
-				<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script> 
-				
-				  <script type='text/javascript'> 
-				  
-
-setInterval(function ( ) {
-
-    $.getJSON('/state', function(data) {
-    // Récupérer les données du JSON
-
-        document.getElementById("state").innerHTML = data.power;
-        document.getElementById("sigma").innerHTML = data.temperature;
-
-      });
-}, 2000);
-
-		
-		</script >
-		
-<script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-<script>
-
-</script>
-
-            
-				  
-				  </div>
-				  
-                  
-
-				   
-				  
+              <!-- Earnings (Monthly) Card Example -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-info shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                          Température
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="sigma">%SIGMA%</span>
+                        </div>
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-dollar-sign fa-2x text-gray-300"></i>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
+
+              <script
+                type="text/javascript"
+                src="https://www.gstatic.com/charts/loader.js"
+              ></script>
+
+              <script type="text/javascript">
+                setInterval(function () {
+                  $.getJSON("/state", function (data) {
+                    // Récupérer les données du JSON
+
+                    document.getElementById("state").innerHTML = data.power;
+                    document.getElementById("sigma").innerHTML = data.temperature;
+                  });
+                }, 2000);
+              </script>
+
+              <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+              <script></script>
             </div>
           </div>
         </div>
-        <!-- /.container-fluid -->
       </div>
-      <!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
-        <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2020</span>
-        </div>
     </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
+        <div class="copyright text-center my-auto">
+          <span>https://github.com/xlyric/ - 2020</span>
+        </div>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data2/index.html
+++ b/data2/index.html
@@ -1,325 +1,334 @@
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer %NAME% - Dashboard</title>
-        
-        <!-- Custom styles for this template-->
-        <link href="all.css" rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version">%VERSION%</span>
-                        <span id="RSSI">RSSI : %RSSI% dBm</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
-            </ul>
-            <!-- End of Sidebar --><!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <div class="alert alert-danger" id="alertBox" ><span class="mr-2 d-none d-lg-inline text-gray-600"></span><p role="alert" id="alertContainer"> </p ></span></div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer %NAME% - Dashboard</title>
 
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <li class="nav-item dropdown no-arrow">
-
-                                    <span class="mr-2 d-none d-lg-inline text-gray-600 small">
-                                        <div id="time">%TIME%</div>
-                                    </span>
-
-                            </li>
-                        </li>
-                        <div class="topbar-divider d-none d-sm-block"></div>
-                    </ul>
-                </nav>
-                <!-- End of Topbar -->
-                <!-- Begin Page Content -->
-                <div class="container-fluid">
-                    <!-- Page Heading -->
-                    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-                        <h1 class="h3 mb-0 text-gray-800">Dashboard</h1>
-                    </div>
-                    <!-- Content Row -->
-                    <div class="row">
-                        <!-- Area Chart -->
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Dimmer</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div id="curve_chart2" style=" width: auto; height: 200px;"></div>
-
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Température</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div id="curve_temp" style=" width: auto; height: 200px;"></div>
-
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-3 col-md-6 mb-4">
-                            <div class="card shadow mb-4">
-                                <!-- Card Header - Dropdown -->
-                                <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-                                    <h6 class="m-0 font-weight-bold text-primary">Etats</h6>
-                                </div>
-                                <div class="card-body">
-                                <b>Etat Ballon : </b><h4 id="alerte">N/A</h4>
-                                <b>Etat Minuteur : </b><h4 id="minuteur">N/A</h4>
-                                <b>Etat Relais 1 : </b><h4 id="relais 1">N/A</h4>
-                                <b>Etat Relais 2 : </b><h4 id="relais 2">N/A</h4>
-
-                                </div>
-                            </div>
-                        </div>
-                        <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-                        <script type="text/javascript"> 
-				  
-	window.onload=function() {
-  horloge('time');
-};			 
-				  
-				  google.charts.load('current', {'packages':['corechart','gauge']}); 
-				  google.charts.setOnLoadCallback(drawChart);
-				  
-				  var chart ;
-				  var options = { title: 'Oscilloscope Mode', curveType: 'function', legend: { position: 'bottom' } };
-				  var data ;
-				  var inc;
-				  
-				  function drawChart() {    
-
-					var optionsGauge = {           
-          redFrom: 75, 
-          redTo: 100,
-           
-          yellowFrom: 50, 
-          yellowTo: 75, 
-           
-          greenFrom: 0, 
-          greenTo: 50, 
-		  	  
-          minorTicks: 4,
-		  
-          min: 0, 
-          max: 100, 
-           
-          
-        };
-       
-	   	   var optionsGaugetemp = {           
-          redFrom: 80, 
-          redTo: 100,
-           
-          yellowFrom: 70, 
-          yellowTo: 80, 
-           
-          greenFrom: 0, 
-          greenTo: 70, 
-		  	  
-          minorTicks: 5,
-		  
-          min: 0, 
-          max: 100, 
-           
-          
-        };
-	
-	// mise à jour de la jauge  --> 	
-		var gaugePA = new google.visualization.Gauge(document.getElementById('curve_chart2'));
-	    var dataGaugePA = new google.visualization.DataTable();
-	    dataGaugePA.addColumn('string', 'Puissance');
-		dataGaugePA.addColumn('number', 'Value');
-		dataGaugePA.addRows(1);
-		
-	// mise à jour de la jauge  --> 	
-		var gaugePAtemp = new google.visualization.Gauge(document.getElementById('curve_temp'));
-	    var dataGaugePAtemp = new google.visualization.DataTable();
-	    dataGaugePAtemp.addColumn('string', 'Power');
-		dataGaugePAtemp.addColumn('number', 'Value');
-		dataGaugePAtemp.addRows(1);
-
-
-	// récupération valeur sigma et State -->
-				  
-setInterval(function ( ) {
-
-$.getJSON('/state', function(data) {
-// Récupérer les données du JSON
-    var dimmer = data.dimmer;
-    var power = data.power;
-    var temperature = data.temperature;
-    var alerte = data.alerte;
-    var minuteur = data.minuteur;
-    var relais1 = data.relay1;
-    var relais2 = data.relay2;
-
-    // Mettre à jour les éléments HTML
-        dataGaugePA.setValue(0, 0, "Power (W)"); 
-		dataGaugePA.setValue(0, 1, power);
-        var pmaxtemp = parseInt(power *100 / dimmer ); 
-        let pmax = isNaN(pmaxtemp) ? 1000 : pmaxtemp;
-        optionsGauge.max = pmax;
-        optionsGauge.redTo = pmax;
-        optionsGauge.redFrom = parseInt(pmax/2);
-        optionsGauge.yellowTo = parseInt(pmax/2); 
-		gaugePA.draw(dataGaugePA,optionsGauge);
-		
-		dataGaugePAtemp.setValue(0, 0, "Temp °C"); 
-		dataGaugePAtemp.setValue(0, 1, temperature);
-		gaugePAtemp.draw(dataGaugePAtemp,optionsGaugetemp);
-
-    // recupération de l'état de sécurité
-        
-    // ecriture de "refroidissement" dans le div alerte si l'état est à 1
-        if (alerte == 1) {
-            document.getElementById("alerte").innerHTML = "Refroidissement";
-            document.getElementById("alerte").style.color = "red";
-        } else {
-            document.getElementById("alerte").innerHTML = "Normal";
-            document.getElementById("alerte").style.color = "";
-        }
-
-    // ecriture de "minuteur" dans le div minuteur si l'état est à 1
-        if (minuteur == 1) {
-            document.getElementById("minuteur").innerHTML = "Minuteur";
-            document.getElementById("minuteur").style.color = "red";
-        } else {
-            document.getElementById("minuteur").innerHTML = "Non actif";
-            document.getElementById("minuteur").style.color = "";
-        }
-    
-    // ecriture de "ON" dans le div relais 1 si l'état est à 1
-        if (relais1 == 1) {
-            document.getElementById("relais 1").innerHTML = "ON";
-            document.getElementById("relais 1").style.color = "red";
-        } else {
-            document.getElementById("relais 1").innerHTML = "OFF";
-            document.getElementById("relais 1").style.color = "";
-        }
-
-    // ecriture de "ON" dans le div relais 2 si l'état est à 1
-        if (relais2 == 1) {
-            document.getElementById("relais 2").innerHTML = "ON";
-            document.getElementById("relais 2").style.color = "red";
-        } else {
-            document.getElementById("relais 2").innerHTML = "OFF";
-            document.getElementById("relais 2").style.color = "";
-        }
-
-        if (data.alerte && data.alerte.trim() != "" ) {
-            const alertContainer = document.getElementById("alertContainer");
-            alertContainer.innerHTML = "Alerte : " + data.alerte;
-                    $('#alertBox').fadeIn();
-            } else {
-                    $('#alertBox').fadeOut();
-        }
-
-
-
-  });
-}, 5000);
- 			
-		  
- 
-}
-
-function horloge(el) {
-  if(typeof el=="string") { el = document.getElementById(el); }
-  function actualiser() {
-    var date = new Date();
-    var str = date.getHours();
-    str += ':'+(date.getMinutes()<10?'0':'')+date.getMinutes();
-    str += ':'+(date.getSeconds()<10?'0':'')+date.getSeconds();
-    el.innerHTML = str;
-  }
-  actualiser();
-  setInterval(actualiser,1000);
-}
-
-
-                    </script >
-                    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-                    <script>
-                    if (typeof jQuery == 'undefined') {
-                        document.write('<script src="/js/jquery.min.js"><\/script>');
-                    }
-                    </script>
-                </div>
+    <!-- Custom styles for this template-->
+    <link href="all.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer %NAME%</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version">%VERSION%</span>
+            <span id="RSSI">RSSI : %RSSI% dBm</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar --><!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <div class="alert alert-danger" id="alertBox">
+              <span class="mr-2 d-none d-lg-inline text-gray-600"></span>
+              <p role="alert" id="alertContainer"></p>
             </div>
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <li class="nav-item dropdown no-arrow">
+                <span class="mr-2 d-none d-lg-inline text-gray-600 small">
+                  <div id="time">%TIME%</div>
+                </span>
+              </li>
+            </ul>
+            <div class="topbar-divider d-none d-sm-block"></div>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <div class="d-sm-flex align-items-center justify-content-between mb-4">
+              <h1 class="h3 mb-0 text-gray-800">Dashboard</h1>
+            </div>
+            <!-- Content Row -->
+            <div class="row">
+              <!-- Area Chart -->
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Dimmer</h6>
+                  </div>
+                  <div class="card-body">
+                    <div id="curve_chart2" style="width: auto; height: 200px"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Température</h6>
+                  </div>
+                  <div class="card-body">
+                    <div id="curve_temp" style="width: auto; height: 200px"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card shadow mb-4">
+                  <!-- Card Header - Dropdown -->
+                  <div
+                    class="card-header py-3 d-flex flex-row align-items-center justify-content-between"
+                  >
+                    <h6 class="m-0 font-weight-bold text-primary">Etats</h6>
+                  </div>
+                  <div class="card-body">
+                    <b>Etat Ballon : </b>
+                    <h4 id="alerte">N/A</h4>
+                    <b>Etat Minuteur : </b>
+                    <h4 id="minuteur">N/A</h4>
+                    <b>Etat Relais 1 : </b>
+                    <h4 id="relais 1">N/A</h4>
+                    <b>Etat Relais 2 : </b>
+                    <h4 id="relais 2">N/A</h4>
+                  </div>
+                </div>
+              </div>
+              <script
+                type="text/javascript"
+                src="https://www.gstatic.com/charts/loader.js"
+              ></script>
+              <script type="text/javascript">
+                window.onload = function () {
+                  horloge("time");
+                };
+
+                google.charts.load("current", { packages: ["corechart", "gauge"] });
+                google.charts.setOnLoadCallback(drawChart);
+
+                var chart;
+                var options = {
+                  title: "Oscilloscope Mode",
+                  curveType: "function",
+                  legend: { position: "bottom" },
+                };
+                var data;
+                var inc;
+
+                function drawChart() {
+                  var optionsGauge = {
+                    redFrom: 75,
+                    redTo: 100,
+
+                    yellowFrom: 50,
+                    yellowTo: 75,
+
+                    greenFrom: 0,
+                    greenTo: 50,
+
+                    minorTicks: 4,
+
+                    min: 0,
+                    max: 100,
+                  };
+
+                  var optionsGaugetemp = {
+                    redFrom: 80,
+                    redTo: 100,
+
+                    yellowFrom: 70,
+                    yellowTo: 80,
+
+                    greenFrom: 0,
+                    greenTo: 70,
+
+                    minorTicks: 5,
+
+                    min: 0,
+                    max: 100,
+                  };
+
+                  // mise à jour de la jauge  -->
+                  var gaugePA = new google.visualization.Gauge(
+                    document.getElementById("curve_chart2")
+                  );
+                  var dataGaugePA = new google.visualization.DataTable();
+                  dataGaugePA.addColumn("string", "Puissance");
+                  dataGaugePA.addColumn("number", "Value");
+                  dataGaugePA.addRows(1);
+
+                  // mise à jour de la jauge  -->
+                  var gaugePAtemp = new google.visualization.Gauge(
+                    document.getElementById("curve_temp")
+                  );
+                  var dataGaugePAtemp = new google.visualization.DataTable();
+                  dataGaugePAtemp.addColumn("string", "Power");
+                  dataGaugePAtemp.addColumn("number", "Value");
+                  dataGaugePAtemp.addRows(1);
+
+                  // récupération valeur sigma et State -->
+
+                  setInterval(function () {
+                    $.getJSON("/state", function (data) {
+                      // Récupérer les données du JSON
+                      var dimmer = data.dimmer;
+                      var power = data.power;
+                      var temperature = data.temperature;
+                      var alerte = data.alerte;
+                      var minuteur = data.minuteur;
+                      var relais1 = data.relay1;
+                      var relais2 = data.relay2;
+
+                      // Mettre à jour les éléments HTML
+                      dataGaugePA.setValue(0, 0, "Power (W)");
+                      dataGaugePA.setValue(0, 1, power);
+                      var pmaxtemp = parseInt((power * 100) / dimmer);
+                      let pmax = isNaN(pmaxtemp) ? 1000 : pmaxtemp;
+                      optionsGauge.max = pmax;
+                      optionsGauge.redTo = pmax;
+                      optionsGauge.redFrom = parseInt(pmax / 2);
+                      optionsGauge.yellowTo = parseInt(pmax / 2);
+                      gaugePA.draw(dataGaugePA, optionsGauge);
+
+                      dataGaugePAtemp.setValue(0, 0, "Temp °C");
+                      dataGaugePAtemp.setValue(0, 1, temperature);
+                      gaugePAtemp.draw(dataGaugePAtemp, optionsGaugetemp);
+
+                      // recupération de l'état de sécurité
+
+                      // ecriture de "refroidissement" dans le div alerte si l'état est à 1
+                      if (alerte == 1) {
+                        document.getElementById("alerte").innerHTML = "Refroidissement";
+                        document.getElementById("alerte").style.color = "red";
+                      } else {
+                        document.getElementById("alerte").innerHTML = "Normal";
+                        document.getElementById("alerte").style.color = "";
+                      }
+
+                      // ecriture de "minuteur" dans le div minuteur si l'état est à 1
+                      if (minuteur == 1) {
+                        document.getElementById("minuteur").innerHTML = "Minuteur";
+                        document.getElementById("minuteur").style.color = "red";
+                      } else {
+                        document.getElementById("minuteur").innerHTML = "Non actif";
+                        document.getElementById("minuteur").style.color = "";
+                      }
+
+                      // ecriture de "ON" dans le div relais 1 si l'état est à 1
+                      if (relais1 == 1) {
+                        document.getElementById("relais 1").innerHTML = "ON";
+                        document.getElementById("relais 1").style.color = "red";
+                      } else {
+                        document.getElementById("relais 1").innerHTML = "OFF";
+                        document.getElementById("relais 1").style.color = "";
+                      }
+
+                      // ecriture de "ON" dans le div relais 2 si l'état est à 1
+                      if (relais2 == 1) {
+                        document.getElementById("relais 2").innerHTML = "ON";
+                        document.getElementById("relais 2").style.color = "red";
+                      } else {
+                        document.getElementById("relais 2").innerHTML = "OFF";
+                        document.getElementById("relais 2").style.color = "";
+                      }
+
+                      if (data.alerte && data.alerte.trim() != "") {
+                        const alertContainer = document.getElementById("alertContainer");
+                        alertContainer.innerHTML = "Alerte : " + data.alerte;
+                        $("#alertBox").fadeIn();
+                      } else {
+                        $("#alertBox").fadeOut();
+                      }
+                    });
+                  }, 5000);
+                }
+
+                function horloge(el) {
+                  if (typeof el == "string") {
+                    el = document.getElementById(el);
+                  }
+                  function actualiser() {
+                    var date = new Date();
+                    var str = date.getHours();
+                    str += ":" + (date.getMinutes() < 10 ? "0" : "") + date.getMinutes();
+                    str += ":" + (date.getSeconds() < 10 ? "0" : "") + date.getSeconds();
+                    el.innerHTML = str;
+                  }
+                  actualiser();
+                  setInterval(actualiser, 1000);
+                }
+              </script>
+              <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+              <script>
+                if (typeof jQuery == "undefined") {
+                  document.write('<script src="/js/jquery.min.js"><\/script>');
+                }
+              </script>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
-</div>
-</div>
-<!-- /.container-fluid -->
-</div>
-<!-- End of Main Content --><!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- /.container-fluid -->
+    <!-- End of Main Content --><!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2020</span>
+          <span>https://github.com/xlyric/ - 2020</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+  </body>
 </html>

--- a/data2/log.html
+++ b/data2/log.html
@@ -1,52 +1,236 @@
 <!DOCTYPE html>
 <html lang="fr" class="">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
-        <title>
-            Console logs
-        </title>
-        <script>
-var x=null,lt,to,tp,pc='';eb=s=>document.getElementById(s);qs=s=>document.querySelector(s);sp=i=>eb(i).type=(eb(i).type==='text'?'password':'text');
-wl=f=>window.addEventListener('load',f);var sn=0,id=0,ft,ltm=2345;function l(p){var c,o='';clearTimeout(lt);clearTimeout(ft);t=eb('t1');if(p==1){c=eb('c1');o='&c1='+encodeURIComponent(c.value);c.value='';t.scrollTop=1e8;sn=t.scrollTop;}if(t.scrollTop>=sn){if(x!=null){x.abort();}
-x=new XMLHttpRequest();x.onreadystatechange=()=>{if(x.readyState==4&&x.status==200){var z,d;d=x.responseText.split(/}1/);id=d.shift();if(d.shift()==0){t.value='';}z=d.shift();
-if(z.length>0){t.value+=z;}t.scrollTop=1e8;sn=t.scrollTop;clearTimeout(ft);lt=setTimeout(l,ltm);}};x.open('GET','cs?c2='+id+o,true);x.send();ft=setTimeout(l,2e4);}else{lt=setTimeout(l,ltm);}return false;}wl(l);
-var hc=[],cn=0;function h(){eb('c1').addEventListener('keydown',e=>{var b=eb('c1'),c=e.keyCode;if(38==c||40==c){b.autocomplete='off';setTimeout(b=>{b.focus();
-b.setSelectionRange(1e9,1e9)},0,b)}38==c?(++cn>hc.length&&(cn=hc.length),b.value=hc[cn-1]||''):40==c?(0>--cn&&(cn=0),b.value=hc[cn-1]||''):13==c&&(hc.length>19&&hc.pop(),hc.unshift(b.value),cn=0)});}wl(h);function jd(){var t=0,i=document.querySelectorAll('input,button,textarea,select');
-while(i.length>=t){if(i[t]){i[t]['name']=(i[t].hasAttribute('id')&&(!i[t].hasAttribute('name')))?i[t]['id']:i[t]['name'];}t++;}}function sf(s){var t=0,i=document.querySelectorAll('.hf');while(i.length>=t){if(i[t]){i[t].style.display=s?'block':'none';}t++;}}wl(jd);
-        </script>
-        <style>
-div,fieldset,input,select{padding:5px;font-size:1em;}fieldset{background:#4f4f4f;}p{margin:0.5em 0;}input{width:100%;box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;background:#dddddd;color:#000000;}input[type=checkbox],input[type=radio]{width:1em;margin-right:6px;vertical-align:-1px;}input[type=range]{width:99%;}select{width:100%;background:#dddddd;color:#000000;}textarea{resize:vertical;width:98%;height:318px;padding:5px;overflow:auto;background:#1f1f1f;color:#65c115;}body{text-align:center;font-family:verdana,sans-serif;background:#252525;}td{padding:0px;}button{border:0;border-radius:0.3rem;background:#1fa3ec;color:#faffff;line-height:2.4rem;font-size:1.2rem;width:100%;-webkit-transition-duration:0.4s;transition-duration:0.4s;cursor:pointer;}button:hover{background:#0e70a4;}.bred{background:#d43535;}.bred:hover{background:#931f1f;}.bgrn{background:#47c266;}.bgrn:hover{background:#5aaf6f;}a{color:#1fa3ec;text-decoration:none;}.p{float:left;text-align:left;}.q{float:right;text-align:right;}.r{border-radius:0.3em;padding:2px;margin:6px 2px;}.hf{display:none;}
-        </style>
-    </head>
-    <body>
-        <div style="text-align:left;display:inline-block;color:#eaeaea;min-width:340px;">
-            <div style="text-align:center;color:#eaeaea;">
-                <noscript>
-                    Pour utiliser Le logger, veuillez activer JavaScript
-                    <br>
-                </noscript>
-                <h3>
-                    DATA LOGGER
-                </h3>
-            </div>
-            <br>
-            <textarea
-                readonly
-                id="t1"
-                cols="340"
-                wrap="off"
-            ></textarea>
-            <br>
-            <br>
-        </form>
-        <div id="but2d" style="display: block;"></div>
-        <p>
-        </form>
-    </p>
-    <div style="text-align:right;font-size:11px;">
-        <hr>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
+    <title>Console logs</title>
+    <script>
+      var x = null,
+        lt,
+        to,
+        tp,
+        pc = "";
+      eb = (s) => document.getElementById(s);
+      qs = (s) => document.querySelector(s);
+      sp = (i) => (eb(i).type = eb(i).type === "text" ? "password" : "text");
+      wl = (f) => window.addEventListener("load", f);
+      var sn = 0,
+        id = 0,
+        ft,
+        ltm = 2345;
+      function l(p) {
+        var c,
+          o = "";
+        clearTimeout(lt);
+        clearTimeout(ft);
+        t = eb("t1");
+        if (p == 1) {
+          c = eb("c1");
+          o = "&c1=" + encodeURIComponent(c.value);
+          c.value = "";
+          t.scrollTop = 1e8;
+          sn = t.scrollTop;
+        }
+        if (t.scrollTop >= sn) {
+          if (x != null) {
+            x.abort();
+          }
+          x = new XMLHttpRequest();
+          x.onreadystatechange = () => {
+            if (x.readyState == 4 && x.status == 200) {
+              var z, d;
+              d = x.responseText.split(/}1/);
+              id = d.shift();
+              if (d.shift() == 0) {
+                t.value = "";
+              }
+              z = d.shift();
+              if (z.length > 0) {
+                t.value += z;
+              }
+              t.scrollTop = 1e8;
+              sn = t.scrollTop;
+              clearTimeout(ft);
+              lt = setTimeout(l, ltm);
+            }
+          };
+          x.open("GET", "cs?c2=" + id + o, true);
+          x.send();
+          ft = setTimeout(l, 2e4);
+        } else {
+          lt = setTimeout(l, ltm);
+        }
+        return false;
+      }
+      wl(l);
+      var hc = [],
+        cn = 0;
+      function h() {
+        eb("c1").addEventListener("keydown", (e) => {
+          var b = eb("c1"),
+            c = e.keyCode;
+          if (38 == c || 40 == c) {
+            b.autocomplete = "off";
+            setTimeout(
+              (b) => {
+                b.focus();
+                b.setSelectionRange(1e9, 1e9);
+              },
+              0,
+              b
+            );
+          }
+          38 == c
+            ? (++cn > hc.length && (cn = hc.length), (b.value = hc[cn - 1] || ""))
+            : 40 == c
+            ? (0 > --cn && (cn = 0), (b.value = hc[cn - 1] || ""))
+            : 13 == c && (hc.length > 19 && hc.pop(), hc.unshift(b.value), (cn = 0));
+        });
+      }
+      wl(h);
+      function jd() {
+        var t = 0,
+          i = document.querySelectorAll("input,button,textarea,select");
+        while (i.length >= t) {
+          if (i[t]) {
+            i[t]["name"] =
+              i[t].hasAttribute("id") && !i[t].hasAttribute("name") ? i[t]["id"] : i[t]["name"];
+          }
+          t++;
+        }
+      }
+      function sf(s) {
+        var t = 0,
+          i = document.querySelectorAll(".hf");
+        while (i.length >= t) {
+          if (i[t]) {
+            i[t].style.display = s ? "block" : "none";
+          }
+          t++;
+        }
+      }
+      wl(jd);
+    </script>
+    <style>
+      div,
+      fieldset,
+      input,
+      select {
+        padding: 5px;
+        font-size: 1em;
+      }
+      fieldset {
+        background: #4f4f4f;
+      }
+      p {
+        margin: 0.5em 0;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        background: #dddddd;
+        color: #000000;
+      }
+      input[type="checkbox"],
+      input[type="radio"] {
+        width: 1em;
+        margin-right: 6px;
+        vertical-align: -1px;
+      }
+      input[type="range"] {
+        width: 99%;
+      }
+      select {
+        width: 100%;
+        background: #dddddd;
+        color: #000000;
+      }
+      textarea {
+        resize: vertical;
+        width: 98%;
+        height: 318px;
+        padding: 5px;
+        overflow: auto;
+        background: #1f1f1f;
+        color: #65c115;
+      }
+      body {
+        text-align: center;
+        font-family: verdana, sans-serif;
+        background: #252525;
+      }
+      td {
+        padding: 0px;
+      }
+      button {
+        border: 0;
+        border-radius: 0.3rem;
+        background: #1fa3ec;
+        color: #faffff;
+        line-height: 2.4rem;
+        font-size: 1.2rem;
+        width: 100%;
+        -webkit-transition-duration: 0.4s;
+        transition-duration: 0.4s;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #0e70a4;
+      }
+      .bred {
+        background: #d43535;
+      }
+      .bred:hover {
+        background: #931f1f;
+      }
+      .bgrn {
+        background: #47c266;
+      }
+      .bgrn:hover {
+        background: #5aaf6f;
+      }
+      a {
+        color: #1fa3ec;
+        text-decoration: none;
+      }
+      .p {
+        float: left;
+        text-align: left;
+      }
+      .q {
+        float: right;
+        text-align: right;
+      }
+      .r {
+        border-radius: 0.3em;
+        padding: 2px;
+        margin: 6px 2px;
+      }
+      .hf {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div style="text-align: left; display: inline-block; color: #eaeaea; min-width: 340px">
+      <div style="text-align: center; color: #eaeaea">
+        <noscript>
+          Pour utiliser Le logger, veuillez activer JavaScript
+          <br />
+        </noscript>
+        <h3>DATA LOGGER</h3>
+      </div>
+      <br />
+      <textarea readonly id="t1" cols="340" wrap="off"></textarea>
+      <br />
+      <br />
+      <div id="but2d" style="display: block"></div>
+      <p></p>
+      <div style="text-align: right; font-size: 11px">
+        <hr />
+      </div>
     </div>
-</div>
-</body>
+  </body>
 </html>

--- a/data2/mqtt.html
+++ b/data2/mqtt.html
@@ -1,364 +1,355 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title>Pv Dimmer - Configuration MQTT</title>
-        <!-- Custom fonts for this template-->
-        <link href="all.css" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
-        <!-- Custom styles for this template-->
-        <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css"   rel="stylesheet">
-    </head>
-    <body id="page-top">
-        <!-- Page Wrapper -->
-        <div id="wrapper">
-            <!-- Sidebar -->
-            <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
-                    <div class="sidebar-brand-icon rotate-n-15">
-                        <i class="fas fa-laugh-wink"></i>
-                    </div>
-                    <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
-                </a>
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span>
-                        <br>
-                        <span id="version"></span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-                <!-- Heading -->
-                <div class="sidebar-heading">
-                    Interface
-                </div>
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link" href="/">
-                        <i class="fas fa-fw fa-plug"></i>
-                        <span>Retour Index</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="config.html">
-                        <i class="fas fa-fw fa-cog"></i>
-                        <span>Configuration</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="readmqtt">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>Reprise conf par MQTT</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="save">
-                        <i class="fas fa-fw fa-download"></i>
-                        <span>Enregistrer fichier conf</span>
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="/reboot">
-                        <i class="fas fa-fw fa-power-off"></i>
-                        <span>Reboot</span>
-                    </a>
-                </li>
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <!-- Sidebar Toggler (Sidebar) -->
-                <div class="text-center d-none d-md-inline">
-                    <button class="rounded-circle border-0" id="sidebarToggle"></button>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Pv Dimmer - Configuration MQTT</title>
+    <!-- Custom fonts for this template-->
+    <link href="all.css" rel="stylesheet" type="text/css" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+      rel="stylesheet"
+    />
+    <!-- Custom styles for this template-->
+    <link href="https://ota.apper-solaire.org/css/sb-admin-2.min.css" rel="stylesheet" />
+  </head>
+  <body id="page-top">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
+      <!-- Sidebar -->
+      <ul
+        class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion"
+        id="accordionSidebar"
+      >
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/">
+          <div class="sidebar-brand-icon rotate-n-15">
+            <i class="fas fa-laugh-wink"></i>
+          </div>
+          <div class="sidebar-brand-text mx-3">Pv Dimmer</div>
+        </a>
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0" />
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>Dashboard</span>
+            <br />
+            <span id="version"></span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider" />
+        <!-- Heading -->
+        <div class="sidebar-heading">Interface</div>
+        <!-- Nav Item - Pages Collapse Menu -->
+        <li class="nav-item active">
+          <a class="nav-link" href="/">
+            <i class="fas fa-fw fa-plug"></i>
+            <span>Retour Index</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="config.html">
+            <i class="fas fa-fw fa-cog"></i>
+            <span>Configuration</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="readmqtt">
+            <i class="fas fa-fw fa-download"></i>
+            <span>Reprise conf par MQTT</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="save">
+            <i class="fas fa-fw fa-download"></i>
+            <span>Enregistrer fichier conf</span>
+          </a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/reboot">
+            <i class="fas fa-fw fa-power-off"></i>
+            <span>Reboot</span>
+          </a>
+        </li>
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block" />
+        <!-- Sidebar Toggler (Sidebar) -->
+        <div class="text-center d-none d-md-inline">
+          <button class="rounded-circle border-0" id="sidebarToggle"></button>
+        </div>
+      </ul>
+      <!-- End of Sidebar -->
+      <!-- Content Wrapper -->
+      <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content">
+          <!-- Topbar -->
+          <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <!-- Sidebar Toggle (Topbar) -->
+
+            <!-- Topbar Navbar -->
+            <ul class="navbar-nav ml-auto">
+              <!-- Nav Item - Search Dropdown (Visible Only XS) -->
+              <li class="nav-item dropdown no-arrow d-sm-none">
+                <i class="fas fa-search fa-fw"></i>
+
+                <!-- Dropdown - Messages -->
+                <div
+                  class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in"
+                  aria-labelledby="searchDropdown"
+                ></div>
+              </li>
+              <!-- Nav Item - Alerts -->
+              <li class="nav-item dropdown no-arrow mx-1"></li>
+              <div class="topbar-divider d-none d-sm-block"></div>
             </ul>
-            <!-- End of Sidebar -->
-            <!-- Content Wrapper -->
-            <div id="content-wrapper" class="d-flex flex-column">
-                <!-- Main Content -->
-                <div id="content">
-                    <!-- Topbar -->
-                    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-                        <!-- Sidebar Toggle (Topbar) -->
-
-          <!-- Topbar Navbar -->
-                        <ul class="navbar-nav ml-auto">
-                            <!-- Nav Item - Search Dropdown (Visible Only XS) -->
-                            <li class="nav-item dropdown no-arrow d-sm-none">
-
-                                    <i class="fas fa-search fa-fw"></i>
-
-                                <!-- Dropdown - Messages -->
-                                <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown"></div>
-                            </li>
-                            <!-- Nav Item - Alerts -->
-                            <li class="nav-item dropdown no-arrow mx-1">
-                            </li>
-                            <div class="topbar-divider d-none d-sm-block"></div>
-                        </ul>
-                    </nav>
-                    <!-- End of Topbar -->
-                    <!-- Begin Page Content -->
-                    <div class="container-fluid">
-                        <!-- Page Heading -->
-                        <h1 class="h3 mb-2 text-gray-800">Configuration MQTT</h1>
-                        <div class="row">
-                            <div class="col-xl-3 col-md-6 mb-4">
-                                <div class="card border-left-primary shadow h-100 py-2">
-                                    <div class="card-body">
-                                        <div class="row no-gutters align-items-center">
-                                            <div class="col mr-2">
-                                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Sauvegarder sur la flash</div>
-                                                <div class="h5 mb-0 font-weight-bold text-gray-800">
-                                                    <span id="save">
-                                                        <a href="#">SAUVEGARDER</a>
-                                                    </span>
-                                                    <br>
-                                                    <span id="savemsg"></span>
-                                                </div>
-                                            </div>
-                                            <div class="col-auto">
-                                                <i class="fas fa-download fa-2x text-gray-300"></i>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+          </nav>
+          <!-- End of Topbar -->
+          <!-- Begin Page Content -->
+          <div class="container-fluid">
+            <!-- Page Heading -->
+            <h1 class="h3 mb-2 text-gray-800">Configuration MQTT</h1>
+            <div class="row">
+              <div class="col-xl-3 col-md-6 mb-4">
+                <div class="card border-left-primary shadow h-100 py-2">
+                  <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Sauvegarder sur la flash
                         </div>
-                        <div class="col-lg-6">
-                            <div class="card position-relative">
-                                <div class="card-header py-3">
-                                    <h6 class="m-0 font-weight-bold text-primary">Configuration</h6>
-                                    <span id="saveform"></span>
-                                </div>
-                                <div class="card-body">
-                                    <div class="col-lg-12">
-                                        <form
-                                            class="user"
-                                            id="formulaire"
-                                            method="post"
-                                            action=""
-                                        >
-                                            <div class="col-sm-3">
-                                                <div class="custom-control custom-checkbox small">
-                                                    <input type="checkbox" class="custom-control-input" id="MQTT" onchange="sendservermode('MQTT');">
-                                                    <label class="custom-control-label" for="MQTT" >MQTT</label>
-                                                </div>
-                                            </div>
-                                            <div class="form-group">
-                                                Serveur  :
-                                                <input
-                                                    type="text"
-                                                    class="form-control form-control-user"
-                                                    id="server"
-                                                    placeholder="%SERVER%"
-                                                >
-                                            </div>
-                                            <div class="form-group">
-                                                Port  :
-                                                <input
-                                                    type="number"
-                                                    step="1"
-                                                    class="form-control form-control-user"
-                                                    id="port"
-                                                    placeholder="%PORT%"
-                                                >
-                                            </div>
-                                            <div class="form-group">
-                                                Topic Domoticz :
-                                                <input
-                                                    type="text"
-                                                    class="form-control form-control-user"
-                                                    id="topic"
-                                                    placeholder="%TOPIC%"
-                                                >
-                                            </div>
-                                            <div class="form-group">
-                                                User  :
-                                                <input
-                                                    type="text"
-                                                    class="form-control form-control-user"
-                                                    id="user"
-                                                    placeholder="%USER%"
-                                                >
-                                            </div>
-                                            <div class="form-group">
-                                                Password :
-                                                <input
-                                                    type="password"
-                                                    class="form-control form-control-user"
-                                                    id="password"
-                                                    placeholder="%PASSWORD%"
-                                                >
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <br>
-                                    <div class="card position-relative">
-                                        <div class="card-header py-3">
-                                        <h6 class="m-0 font-weight-bold text-primary">Domoticz</h6>
-                                            <span id="saveform"></span>
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="form-group row">
-                                                <div class="col-sm-3">IDX temp</div>
-                                                <div class="col-sm-3">IDX pow</div>
-                                                <div class="col-sm-3">IDX alarme</div>
-                                            </div>
-                                            <div class="form-group row">
-                                                <div class="col-sm-3">
-                                                    <input
-                                                        type="number"
-                                                        step="1"
-                                                        class="form-control form-control-user"
-                                                        id="idxtemp"
-                                                        placeholder="%IDXTEMP%"
-                                                    >
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <input
-                                                        type="number"
-                                                        step="1"
-                                                        class="form-control form-control-user"
-                                                        id="IDX"
-                                                        placeholder="%IDX%"
-                                                    >
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <input
-                                                        type="number"
-                                                        step="1"
-                                                        class="form-control form-control-user"
-                                                        id="IDXAlarme"
-                                                        placeholder="%IDXALARME%"
-                                                    >
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div> 
-                                    <input type="submit" value=" Application des paramètres" class="btn btn-primary btn-user btn-block">
-                                </form>
-
-                            </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                          <span id="save">
+                            <a href="#">SAUVEGARDER</a>
+                          </span>
+                          <br />
+                          <span id="savemsg"></span>
                         </div>
-
-
+                      </div>
+                      <div class="col-auto">
+                        <i class="fas fa-download fa-2x text-gray-300"></i>
+                      </div>
                     </div>
+                  </div>
                 </div>
+              </div>
             </div>
-            <!-- Content Row -->
-            <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-            <script type="text/javascript"> 
-	
+            <div class="col-lg-6">
+              <div class="card position-relative">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Configuration</h6>
+                  <span id="saveform"></span>
+                </div>
+                <form class="user" id="formulaire" method="post" action="">
+                  <div class="card-body">
+                    <div class="col-lg-12">
+                      <div class="col-sm-3">
+                        <div class="custom-control custom-checkbox small">
+                          <input
+                            type="checkbox"
+                            class="custom-control-input"
+                            id="MQTT"
+                            onchange="sendservermode('MQTT');"
+                          />
+                          <label class="custom-control-label" for="MQTT">MQTT</label>
+                        </div>
+                      </div>
+                      <div class="form-group">
+                        Serveur :
+                        <input
+                          type="text"
+                          class="form-control form-control-user"
+                          id="server"
+                          placeholder="%SERVER%"
+                        />
+                      </div>
+                      <div class="form-group">
+                        Port :
+                        <input
+                          type="number"
+                          step="1"
+                          class="form-control form-control-user"
+                          id="port"
+                          placeholder="%PORT%"
+                        />
+                      </div>
+                      <div class="form-group">
+                        Topic Domoticz :
+                        <input
+                          type="text"
+                          class="form-control form-control-user"
+                          id="topic"
+                          placeholder="%TOPIC%"
+                        />
+                      </div>
+                      <div class="form-group">
+                        User :
+                        <input
+                          type="text"
+                          class="form-control form-control-user"
+                          id="user"
+                          placeholder="%USER%"
+                        />
+                      </div>
+                      <div class="form-group">
+                        Password :
+                        <input
+                          type="password"
+                          class="form-control form-control-user"
+                          id="password"
+                          placeholder="%PASSWORD%"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div class="card position-relative">
+                    <div class="card-header py-3">
+                      <h6 class="m-0 font-weight-bold text-primary">Domoticz</h6>
+                      <span id="saveform"></span>
+                    </div>
+                    <div class="card-body">
+                      <div class="form-group row">
+                        <div class="col-sm-3">IDX temp</div>
+                        <div class="col-sm-3">IDX pow</div>
+                        <div class="col-sm-3">IDX alarme</div>
+                      </div>
+                      <div class="form-group row">
+                        <div class="col-sm-3">
+                          <input
+                            type="number"
+                            step="1"
+                            class="form-control form-control-user"
+                            id="idxtemp"
+                            placeholder="%IDXTEMP%"
+                          />
+                        </div>
+                        <div class="col-sm-3">
+                          <input
+                            type="number"
+                            step="1"
+                            class="form-control form-control-user"
+                            id="IDX"
+                            placeholder="%IDX%"
+                          />
+                        </div>
+                        <div class="col-sm-3">
+                          <input
+                            type="number"
+                            step="1"
+                            class="form-control form-control-user"
+                            id="IDXAlarme"
+                            placeholder="%IDXALARME%"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <input
+                    type="submit"
+                    value=" Application des paramètres"
+                    class="btn btn-primary btn-user btn-block"
+                  />
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Content Row -->
+      <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+      <script type="text/javascript">
+        function save() {
+          $.get("/getmqtt", { save: "yes" }).done(function (data) {});
+        }
 
-function save () {				  
-  		$.get( "/getmqtt", { save: "yes" } )
-		.done(function(data) {
-		});		
+        function sendservermode(mode) {
+          $.get("/get", { servermode: mode }).done(function (data) {
+            $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+            var config = data.split(";");
+            document.getElementById("MQTT").value = config[18];
+          });
+        }
+      </script>
 
+      <script>
+        <!-- sauvegarde de la configuration -->
 
-}
+        $("#save").click(function () {
+          $.get("getmqtt", { save: "yes" }).done(function (data) {
+            $("#savemsg").text("Configuration sauvegardée").show().fadeOut(5000);
+          });
+        });
 
-function sendservermode (mode) {
+        $("#formulaire").submit(function () {
+          var data = {
+            hostname: $("#server").val(),
+            port: $("#port").val(),
+            Publish: $("#topic").val(),
+            mqttuser: $("#user").val(),
+            mqttpassword: $("#password").val(),
+            idxtemp: $("#idxtemp").val(),
+            IDXAlarme: $("#IDXAlarme").val(),
+            IDX: $("#IDX").val(),
+          };
 
-$.get( "/get", { servermode: mode } )
-.done(function(data) { 
-$( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-var config = data.split(";");
-document.getElementById("MQTT").value = config[18];
-}); 
-
-
-}
-		
-		</script>
-
-            <script>
-
-<!-- sauvegarde de la configuration --> 
-
-$( "#save" ).click(function() {
-
-  
-  		$.get( "getmqtt", { save: "yes" } )
-		.done(function(data) {
-		$( "#savemsg" ).text( "Configuration sauvegardée" ).show().fadeOut( 5000 );
-		});	
-		
-
-});
-
-$( "#formulaire" ).submit(function() {
-
-	 var data = {'hostname':$('#server').val(), 'port':$('#port').val(), 'Publish':$('#topic').val(), 'mqttuser':$('#user').val(), 'mqttpassword':$('#password').val(), 'idxtemp':$('#idxtemp').val(), 'IDXAlarme':$('#IDXAlarme').val(), 'IDX':$('#IDX').val()} 
-
-        $.ajax({
+          $.ajax({
             type: "GET",
             data: data,
             url: "get",
 
-            success: function(retour){
-                $( "#saveform" ).text( "Configuration appliquée" ).show().fadeOut( 5000 );
-                     
-            }
+            success: function (retour) {
+              $("#saveform").text("Configuration appliquée").show().fadeOut(5000);
+            },
+          });
+          return false;
         });
-  return false;
-});
 
-
-var recupconfig =  $.getJSON('/getmqtt', function(data) {
-  for (var key in data) {
-    if (data.hasOwnProperty(key)) {
-      var element = document.getElementById(key);
-      if (element) {
-        element.value = data[key];
-        if (element.type === 'checkbox') {
-          element.checked = data[key];
-        }
-      }
-    }
-  }
-});
-
-            </script>
-        </div>
+        var recupconfig = $.getJSON("/getmqtt", function (data) {
+          for (var key in data) {
+            if (data.hasOwnProperty(key)) {
+              var element = document.getElementById(key);
+              if (element) {
+                element.value = data[key];
+                if (element.type === "checkbox") {
+                  element.checked = data[key];
+                }
+              }
+            }
+          }
+        });
+      </script>
     </div>
-</div>
-</div>
-</div>
-<!-- /.container-fluid -->
-</div>
-<!-- End of Main Content -->
-<!-- Footer -->
-<footer class="sticky-footer bg-white">
-    <div class="container my-auto">
+    <!-- End of Main Content -->
+    <!-- Footer -->
+    <footer class="sticky-footer bg-white">
+      <div class="container my-auto">
         <div class="copyright text-center my-auto">
-            <span>https://github.com/xlyric/  - 2023</span>
+          <span>https://github.com/xlyric/ - 2023</span>
         </div>
-    </div>
-</footer>
-<!-- End of Footer -->
-</div>
-<!-- End of Content Wrapper -->
-</div>
-<!-- End of Page Wrapper -->
-<!-- Bootstrap core JavaScript-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js" ></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js" ></script>
-<!-- Core plugin JavaScript-->
-<script src="https://ota.apper-solaire.org/css/jquery.easing.min.js" ></script>
-<!-- Custom scripts for all pages-->
-<script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
-<script></script>
-
-
-</body>
+      </div>
+    </footer>
+    <!-- End of Footer -->
+    <!-- End of Page Wrapper -->
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script>
+      if (typeof jQuery == "undefined") {
+        document.write('<script src="/js/jquery.min.js"><\/script>');
+      }
+    </script>
+    <!-- Bootstrap core JavaScript-->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+    <!-- Core plugin JavaScript-->
+    <script src="https://ota.apper-solaire.org/css/jquery.easing.min.js"></script>
+    <!-- Custom scripts for all pages-->
+    <script src="https://ota.apper-solaire.org/css/sb-admin-2.js"></script>
+    <script></script>
+  </body>
 </html>

--- a/data2/template/lang_en.json
+++ b/data2/template/lang_en.json
@@ -1,3 +1,3 @@
 {
-    "default_language": "en"
+  "default_language": "en"
 }

--- a/data2/template/lang_fr.json
+++ b/data2/template/lang_fr.json
@@ -1,3 +1,3 @@
 {
-    "default_language": "fr"
+  "default_language": "fr"
 }

--- a/data2/template/lang_ua.json
+++ b/data2/template/lang_ua.json
@@ -1,3 +1,3 @@
 {
-    "default_language": "ua"
+  "default_language": "ua"
 }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -1,65 +1,64 @@
 #ifndef CONFIG
 #define CONFIG
 
-#define VERSION "Version 20240905" 
+#define VERSION "Version 20240905"
 #define FS_RELEASE "20240701" // date de la release
 
 #define TEMPERATURE_PRECISION 10
-//// configuration for Standalone boards ( personnalisation )
+// configuration for Standalone boards ( personnalisation )
 #ifdef  STANDALONE
 
 // TMP RV - I use this one for my v1.4 dimmer boards
-  #define ONE_WIRE_BUS D7 // Dallas 
+  #define ONE_WIRE_BUS D7 // Dallas
 
-  #define zerocross  D6   // for boards with CHANGEBLE input pins
-  #define outputPin  D5   // use DIMMER (SSR1) output for 1st Robotdyn/Random SSR
-  #define outputPin2 D1   // use JOTTA (SSR2) output for 2nd Robotdyn/Random SSR
-  //#define outputPin3  D0 // A venir avec la future carte v1.5 - // use SSR3 output for 3rd Robotdyn/Random SSR
-  #define outputPin3 D2   // (SSR3) use RELAY2 output for 3rd Robotdyn/Random SSR ( for old boards )
-  
+  #define zerocross  D6     // for boards with CHANGEBLE input pins
+  #define outputPin  D5     // use DIMMER (SSR1) output for 1st Robotdyn/Random SSR
+  #define outputPin2 D1     // use JOTTA (SSR2) output for 2nd Robotdyn/Random SSR
+// #define outputPin3  D0 // A venir avec la future carte v1.5 - // use SSR3 output for 3rd Robotdyn/Random SSR
+  #define outputPin3 D2     // (SSR3) use RELAY2 output for 3rd Robotdyn/Random SSR ( for old boards )
+
   #define RELAY1 D3     // Spécial pour relay commandé Relay 1
-  //#define RELAY2 D2   // Normal pin for RELAY 2 - Temp. reused for SSR3
-  #define RELAY2 D0     // Relay 2 
+// #define RELAY2 D2    // Normal pin for RELAY 2 - Temp. reused for SSR3
+  #define RELAY2 D0     // Relay 2
   #define COOLER D8     /// 0 : off  -> 1 : On --> need a dry contact or opto
-  
+
 #endif
 
-//// configuration for Dimmer with Power supply and D1 Mini on the board and need TTL USB ( https://fr.aliexpress.com/item/1005003365062050.html ) 
+//// configuration for Dimmer with Power supply and D1 Mini on the board and need TTL USB ( https://fr.aliexpress.com/item/1005003365062050.html )
 #ifdef  POWERSUPPLY2022
 #define outputPin  4
 #define zerocross  5 // for boards with CHANGEBLE input pins
 #define COOLER  D7   /// 0 : off  -> 1 : On --> need a dry contact or opto
 
-/// Dallas 
-#define ONE_WIRE_BUS 12  
-#define GND_PIN 14 
+/// Dallas
+#define ONE_WIRE_BUS 12
+#define GND_PIN 14
 #define POS_PIN 02
 
 #endif
 
-#ifdef  SSR  /// même pin que le stand alone 
+#ifdef  SSR  /// même pin que le stand alone
   #define JOTTA  D1 // for boards with CHANGEBLE input pins
-  #define ONE_WIRE_BUS D7 // dallas 
-  #define GRIDFREQ 50 ///PWM frequency
-  #define outputPin  D5 
+  #define ONE_WIRE_BUS D7 // dallas
+  #define GRIDFREQ 50 /// PWM frequency
+  #define outputPin  D5
   #define zerocross  D6
   #define COOLER  D8   /// 0 : off  -> 1 : On --> need a dry contact or opto
-  #define RELAY1 D3  // Spécial pour relay commandé 
+  #define RELAY1 D3  // Spécial pour relay commandé
   #define RELAY2 D2  //
 #endif
 
 
 #ifdef ESP32
-  #define RELAY2 26 
+  #define RELAY2 26
   #define outputPin  18 // PSM on board
   #define zerocross  19 // for boards with CHANGEBLE input pins // ZC on board
   #define ONE_WIRE_BUS  23 // Dallas
   #define COOLER 5 // Pin for COOLER. (switch on dimmer)
-  
+
   #define outputPin2 22 // use JOTTA/SSR2 (SSR2) output for 2nd Robotdyn/Random SSR
   #define outputPin3 21  // (SSR3) use RELAY2/SSR3 output for 3rd Robotdyn/Random SSR ( for old boards )
-  #define RELAY1 17 
-  
+  #define RELAY1 17
 #endif
 
 #ifdef ESP32ETH
@@ -72,11 +71,11 @@
 #undef COOLER
 
 #define outputPin    15
-//#define outputPin2   14 /// désactivé pour le moment
+// #define outputPin2   14 // désactivé pour le moment
 #define zerocross    36
-#define ONE_WIRE_BUS 12 
-//#define RELAY1       2 
-//#define RELAY2       4 
+#define ONE_WIRE_BUS 12
+// #define RELAY1       2
+// #define RELAY2       4
 #define COOLER       5
 
 #define ETH_CLK_MODE    ETH_CLOCK_GPIO17_OUT
@@ -87,14 +86,14 @@
 #define ETH_MDIO_PIN    18
 #endif
 
-/// Trigger for temp limit in percent
-//#define TRIGGER 10   /// 
+// Trigger for temp limit in percent
+// #define TRIGGER 10
 #define TIMERDELAY 5 // delay before switch off
 
 #define LOG_MAX_STRING_LENGTH 1500 // taille max des logs stockées
 
-/// activation mode debug
-//#define Debug
+// activation mode debug
+// #define Debug
   #ifdef Debug
     #define DEBUG_PRINTLN(x) Serial.println(x)
   #else
@@ -105,13 +104,13 @@
 #define NTP_SERVER "europe.pool.ntp.org"
 #define NTP_UPDATE_INTERVAL_MS 3600000 /// synch de l'heure toute les heures
 
-/// deprecated description old version Robotdyn card 2021 ( With wemos D1 mini plugged on the board)
-//// configuration for Dimmer with Power supply and D1 Mini on the board and need TTL USB ( https://fr.aliexpress.com/item/1005003365062050.html ) 
+// deprecated description old version Robotdyn card 2021 ( With wemos D1 mini plugged on the board)
+// configuration for Dimmer with Power supply and D1 Mini on the board and need TTL USB ( https://fr.aliexpress.com/item/1005003365062050.html )
 #ifdef  POWERSUPPLY
-#define outputPin  D0 
-#define zerocross  D1 // for boards with CHANGEBLE input pins
-#define ONE_WIRE_BUS D2 // previously D2 was not working on old robotdyn card
-#define COOLER  D7   /// 0 : off  -> 1 : On --> need a dry contact or opto
+#define outputPin  D0
+#define zerocross  D1    // for boards with CHANGEBLE input pins
+#define ONE_WIRE_BUS D2  // previously D2 was not working on old robotdyn card
+#define COOLER  D7       // 0 : off  -> 1 : On --> need a dry contact or opto
 #endif
 
 

--- a/src/config/enums.h
+++ b/src/config/enums.h
@@ -12,7 +12,7 @@
 #if defined(ESP32) || defined(ESP32ETH)
   #include <FS.h>
   #include "SPIFFS.h"
-  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct? 
+  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct?
 #else
   #include <LittleFS.h> // NOSONAR
 #endif
@@ -23,103 +23,108 @@ constexpr const int MAX_DALLAS=8; // nombre de sonde Dallas
 /// @brief  partie délicate car pas mal d'action sur la variable log_init et donc protection de la variable ( pour éviter les pb mémoire )
 struct Logs {
 private:
-     
-      char log_init[LOG_MAX_STRING_LENGTH]; // NOSONAR
-      int MaxString = LOG_MAX_STRING_LENGTH * .9 ;
-      String alerte_web = "";
+
+  char log_init[LOG_MAX_STRING_LENGTH];     // NOSONAR
+  int MaxString = LOG_MAX_STRING_LENGTH * .9;
+  String alerte_web = "";
 
 public:
-    /// setter alerte_web
-    void Set_alerte_web(String setter) {
-        alerte_web = setter;
+  /// setter alerte_web
+  void Set_alerte_web(String setter) {
+    alerte_web = setter;
+  }
+  /// getter alerte_web
+  String Get_alerte_web() {
+    return alerte_web;
+  }
+
+
+/// setter log_init
+public: void Set_log_init(String setter, bool logtime=false) {
+    // Vérifier si la longueur de la chaîne ajoutée ne dépasse pas LOG_MAX_STRING_LENGTH
+    if ( strlen(setter.c_str()) + strlen(log_init) < static_cast<size_t>(MaxString) )  {
+      if (logtime) {
+        if ( strlen(setter.c_str()) + strlen(log_init) + strlen(loguptime()) < static_cast<size_t>(MaxString))  {
+          strcat(log_init,loguptime());
+        }
+      }
+      strcat(log_init,setter.c_str());
+    } else {
+      // Si la taille est trop grande, réinitialiser le log_init
+      reset_log_init();
     }
-    /// getter alerte_web 
-    String Get_alerte_web() { return alerte_web; }
+  }
 
+  /// getter log_init
+  String Get_log_init() {
+    return log_init;
+  }
 
-  ///setter log_init
-    public:void Set_log_init(String setter, bool logtime=false) {
-        // Vérifier si la longueur de la chaîne ajoutée ne dépasse pas LOG_MAX_STRING_LENGTH
-        if ( strlen(setter.c_str()) + strlen(log_init) < static_cast<size_t>(MaxString) )  { 
-            if (logtime) { 
-              if ( strlen(setter.c_str()) + strlen(log_init) + strlen(loguptime()) < static_cast<size_t>(MaxString))  { 
-                strcat(log_init,loguptime()); }
-              }
-          strcat(log_init,setter.c_str());  
-        } else {  
-          // Si la taille est trop grande, réinitialiser le log_init
-          reset_log_init();
-        }     
-      }
+  // clean log_init
+  void clean_log_init() {
+    // Vérifier si la longueur de log_init dépasse 90% de LOG_MAX_STRING_LENGTH
+    if (strlen(log_init) > static_cast<size_t>(MaxString) ) {
+      reset_log_init();
+    }
+  }
 
-    ///getter log_init
-      String Get_log_init() {return log_init; }
-
-      //clean log_init
-      void clean_log_init() {
-          // Vérifier si la longueur de log_init dépasse 90% de LOG_MAX_STRING_LENGTH
-          if (strlen(log_init) > static_cast<size_t>(MaxString) ) {
-              reset_log_init();
-          }
-      }
-
-    //reset log_init
-      void reset_log_init() {
-        log_init[0] = '\0';
-        strcat(log_init,"197}11}1");
-      }
+  // reset log_init
+  void reset_log_init() {
+    log_init[0] = '\0';
+    strcat(log_init,"197}11}1");
+  }
 
   char *loguptime(bool day=false) {
-      static char uptime_stamp[20]; // Vous devrez définir une taille suffisamment grande pour stocker votre temps
-        time_t maintenant;
-        time(&maintenant);
-      if (day) {
-        strftime(uptime_stamp, sizeof(uptime_stamp), "%d/%m/%Y %H:%M:%S\t ", localtime(&maintenant));
-      } else {
-        strftime(uptime_stamp, sizeof(uptime_stamp), "%H:%M:%S\t ", localtime(&maintenant));
-      }
-      return uptime_stamp;
+    static char uptime_stamp[20];   // Vous devrez définir une taille suffisamment grande pour stocker votre temps
+    time_t maintenant;
+    time(&maintenant);
+    if (day) {
+      strftime(uptime_stamp, sizeof(uptime_stamp), "%d/%m/%Y %H:%M:%S\t ", localtime(&maintenant));
+    } else {
+      strftime(uptime_stamp, sizeof(uptime_stamp), "%H:%M:%S\t ", localtime(&maintenant));
     }
-  
+    return uptime_stamp;
+  }
+
 };
 
 
 struct Config {
-    
-  public:
-    const char *filename_conf = "/config.json";
-    char hostname[16] = "192.168.1.22"; // NOSONAR
-    int port = 1883 ;
-    char Publish[100] = "domoticz/in"; // NOSONAR 
-    int IDXTemp = 200;
-    int IDXAlarme = 202;
-    int IDX = 201; 
-    int maxtemp = 60;
-    int maxpow = 50;
-    char child[64] = "";
-    char mode[10] = "off";
-    int minpow = 5;
-    int startingpow = 0;
-    char SubscribePV[100] = "none";
-    char SubscribeTEMP[100] ="none" ; // NOSONAR
-    bool restart;
-    bool dimmer_on_off = true;
+
+public:
+  const char *filename_conf = "/config.json";
+  char hostname[16] = "192.168.1.22";   // NOSONAR
+  int port = 1883;
+  char Publish[100] = "domoticz/in";   // NOSONAR
+  int IDXTemp = 200;
+  int IDXAlarme = 202;
+  int IDX = 201;
+  int maxtemp = 60;
+  int maxpow = 50;
+  char child[64] = "";
+  char mode[10] = "off";
+  int minpow = 5;
+  int startingpow = 0;
+  char SubscribePV[100] = "none";
+  char SubscribeTEMP[100] ="none";    // NOSONAR
+  bool restart;
+  bool dimmer_on_off = true;
   /// @brief  // Somme des 3 charges déclarées dans la page web
-    int charge = 1000;
+  int charge = 1000;
   /// @brief  // Puissance de la charge 1 déclarée dans la page web
-    int charge1 = 1000; 
+  int charge1 = 1000;
   /// @brief  // Puissance de la charge 2 déclarée dans la page web
-    int charge2 = 0; 
+  int charge2 = 0;
   /// @brief  // Puissance de la charge 3 déclarée dans la page web
-    int charge3 = 0; 
-    int dispo = 0; 
-    bool HA = true;
-    bool JEEDOM = true;
-    bool DOMOTICZ = true;
-    char PVROUTER[5] = "mqtt";
-    char DALLAS[17]   = "none";
-    char say_my_name[32] = "" ; // NOSONAR
-    int trigger = 0;
+  int charge3 = 0;
+  int dispo = 0;
+  bool HA = true;
+  bool JEEDOM = true;
+  bool DOMOTICZ = true;
+  char PVROUTER[5] = "mqtt";
+  char DALLAS[17]   = "none";
+  char say_my_name[32] = "";    // NOSONAR
+  int trigger = 0;
 
   void check_trigger() {
     if (trigger < 0) { trigger = 0; }
@@ -127,144 +132,144 @@ struct Config {
   }
 
 // Loads the configuration from a file
-String loadConfiguration() {
-  String message = "";
-  // Open file for reading
-  File configFile = LittleFS.open(filename_conf, "r");
+  String loadConfiguration() {
+    String message = "";
+    // Open file for reading
+    File configFile = LittleFS.open(filename_conf, "r");
 
-   // Allocate a temporary JsonDocument
-  // Don't forget to change the capacity to match your requirements.
-  // Use arduinojson.org/v6/assistant to compute the capacity.
-  JsonDocument doc;
+    // Allocate a temporary JsonDocument
+    // Don't forget to change the capacity to match your requirements.
+    // Use arduinojson.org/v6/assistant to compute the capacity.
+    JsonDocument doc;
 
-  // Deserialize the JSON document
-  DeserializationError error = deserializeJson(doc, configFile);
-  if (error) {
-    Serial.println(F("Failed to read configuration file, using default configuration"));
-    message = "Failed to read file config File, use default\r\n" ;
+    // Deserialize the JSON document
+    DeserializationError error = deserializeJson(doc, configFile);
+    if (error) {
+      Serial.println(F("Failed to read configuration file, using default configuration"));
+      message = "Failed to read file config File, use default\r\n";
     }
-  // Copy values from the JsonDocument to the Config
+    // Copy values from the JsonDocument to the Config
 
-/// en cas de reboot étranges, il sera bon de passer sur un format de type doc["hostname"].as<String>().c_str() pour éviter les problèmes de mémoire  
-/// --> Exception 9: LoadStoreAlignmentCause: Load or store to an unaligned address. cas survenu avec les configuration MQTT
-  String hostnamevalue = doc["hostname"].as<String>();
-  strlcpy(hostname, hostnamevalue.c_str(), sizeof(hostname));
+    /// en cas de reboot étranges, il sera bon de passer sur un format de type doc["hostname"].as<String>().c_str() pour éviter les problèmes de mémoire
+    /// --> Exception 9: LoadStoreAlignmentCause: Load or store to an unaligned address. cas survenu avec les configuration MQTT
+    String hostnamevalue = doc["hostname"].as<String>();
+    strlcpy(hostname, hostnamevalue.c_str(), sizeof(hostname));
 
-  port = doc["port"] | 1883;
+    port = doc["port"] | 1883;
 
-  String PublishValue = doc["Publish"].as<String>();
-  strlcpy(Publish, PublishValue.c_str(), sizeof(Publish));
-  
-  IDXTemp = doc["IDXTemp"] | 200; 
-  maxtemp = doc["maxtemp"] | 60; 
-  IDXAlarme = doc["IDXAlarme"] | 202; 
-  IDX = doc["IDX"] | 201; 
-  startingpow = doc["startingpow"] | 0; 
-  minpow = doc["minpow"] | 5;
-  maxpow = doc["maxpow"] | 50; 
-  charge = doc["charge"] | 1000; 
-  charge1 = doc["charge1"] | 1000; 
-  charge2 = doc["charge2"] | 0; 
-  charge3 = doc["charge3"] | 0; 
-  trigger = doc["trigger"] | 10;
-  check_trigger();
+    String PublishValue = doc["Publish"].as<String>();
+    strlcpy(Publish, PublishValue.c_str(), sizeof(Publish));
 
-  String Publishchild = doc["child"].as<String>();
-  strlcpy(child, Publishchild.c_str(), sizeof(child));
-  
-  String Publishmode = doc["mode"].as<String>();
-  strlcpy(mode, Publishmode.c_str(), sizeof(mode));
-  
-  String PublishSubscribePV = doc["SubscribePV"].as<String>();
-  strlcpy(SubscribePV, PublishSubscribePV.c_str(), sizeof(SubscribePV));
+    IDXTemp = doc["IDXTemp"] | 200;
+    maxtemp = doc["maxtemp"] | 60;
+    IDXAlarme = doc["IDXAlarme"] | 202;
+    IDX = doc["IDX"] | 201;
+    startingpow = doc["startingpow"] | 0;
+    minpow = doc["minpow"] | 5;
+    maxpow = doc["maxpow"] | 50;
+    charge = doc["charge"] | 1000;
+    charge1 = doc["charge1"] | 1000;
+    charge2 = doc["charge2"] | 0;
+    charge3 = doc["charge3"] | 0;
+    trigger = doc["trigger"] | 10;
+    check_trigger();
 
-  String PublishSubscribeTEMP = doc["SubscribeTEMP"].as<String>();   
-  strlcpy(SubscribeTEMP, PublishSubscribeTEMP.c_str(), sizeof(SubscribeTEMP));
-  
-  dimmer_on_off = doc["dimmer_on_off"] | 1; 
-  HA = doc["HA"] | true; 
-  JEEDOM = doc["JEEDOM"] | true; 
-  DOMOTICZ = doc["DOMOTICZ"] | true; 
+    String Publishchild = doc["child"].as<String>();
+    strlcpy(child, Publishchild.c_str(), sizeof(child));
 
-  String PublishPVROUTER = doc["PVROUTER"].as<String>();
-  strlcpy(PVROUTER, PublishPVROUTER.c_str(), sizeof(PVROUTER));
+    String Publishmode = doc["mode"].as<String>();
+    strlcpy(mode, Publishmode.c_str(), sizeof(mode));
 
-  String PublishDALLAS = doc["DALLAS"].as<String>();
-  strlcpy(DALLAS, PublishDALLAS.c_str(), sizeof(DALLAS));
+    String PublishSubscribePV = doc["SubscribePV"].as<String>();
+    strlcpy(SubscribePV, PublishSubscribePV.c_str(), sizeof(SubscribePV));
 
-  String Publishsay_my_name = doc["name"].as<String>();
-  if (strcmp(Publishsay_my_name.c_str(), "") == 0 || strcmp(Publishsay_my_name.c_str(), "null" ) == 0 ) {
+    String PublishSubscribeTEMP = doc["SubscribeTEMP"].as<String>();
+    strlcpy(SubscribeTEMP, PublishSubscribeTEMP.c_str(), sizeof(SubscribeTEMP));
+
+    dimmer_on_off = doc["dimmer_on_off"] | 1;
+    HA = doc["HA"] | true;
+    JEEDOM = doc["JEEDOM"] | true;
+    DOMOTICZ = doc["DOMOTICZ"] | true;
+
+    String PublishPVROUTER = doc["PVROUTER"].as<String>();
+    strlcpy(PVROUTER, PublishPVROUTER.c_str(), sizeof(PVROUTER));
+
+    String PublishDALLAS = doc["DALLAS"].as<String>();
+    strlcpy(DALLAS, PublishDALLAS.c_str(), sizeof(DALLAS));
+
+    String Publishsay_my_name = doc["name"].as<String>();
+    if (strcmp(Publishsay_my_name.c_str(), "") == 0 || strcmp(Publishsay_my_name.c_str(), "null" ) == 0 ) {
       strcpy(say_my_name, ("dimmer-"+WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17)).c_str());
     }
-  else strlcpy(say_my_name, Publishsay_my_name.c_str(), sizeof(say_my_name));
+    else strlcpy(say_my_name, Publishsay_my_name.c_str(), sizeof(say_my_name));
 
-  configFile.close();
+    configFile.close();
 
-  return message;  
-}
+    return message;
+  }
 
 //***********************************
 //************* Gestion de la configuration - sauvegarde du fichier de configuration
 //***********************************
 
-String saveConfiguration() {
-  String message = "";
-  check_trigger();
-  // Open file for writing
-   File configFile = LittleFS.open(filename_conf, "w");
-  if (!configFile) {
-    Serial.println(F("Failed to open config file for writing"));
-    return "Failed to open config file for writing\r\n";
+  String saveConfiguration() {
+    String message = "";
+    check_trigger();
+    // Open file for writing
+    File configFile = LittleFS.open(filename_conf, "w");
+    if (!configFile) {
+      Serial.println(F("Failed to open config file for writing"));
+      return "Failed to open config file for writing\r\n";
+    }
+
+    // Allocate a temporary JsonDocument
+    // Don't forget to change the capacity to match your requirements.
+    // Use arduinojson.org/assistant to compute the capacity.
+    JsonDocument doc;
+
+    // Set the values in the document
+    doc["hostname"] = hostname;
+    doc["port"] = port;
+    doc["Publish"] = Publish;
+    doc["IDXTemp"] = IDXTemp;
+    doc["maxtemp"] = maxtemp;
+    doc["IDXAlarme"] = IDXAlarme;
+    doc["IDX"] = IDX;
+    doc["startingpow"] = startingpow;
+    doc["minpow"] = minpow;
+    doc["maxpow"] = maxpow;
+    doc["child"] = child;
+    doc["mode"] = mode;
+    doc["SubscribePV"] = SubscribePV;
+    doc["SubscribeTEMP"] = SubscribeTEMP;
+    doc["dimmer_on_off"] = dimmer_on_off;
+    doc["charge"] = charge;
+    doc["HA"] = HA;
+    doc["JEEDOM"] = JEEDOM;
+    doc["DOMOTICZ"] = DOMOTICZ;
+    doc["PVROUTER"] = PVROUTER;
+    doc["DALLAS"] = DALLAS;
+    doc["name"] = say_my_name;
+    doc["charge1"] = charge1;
+    doc["charge2"] = charge2;
+    doc["charge3"] = charge3;
+    doc["trigger"] = trigger;
+
+    // Serialize JSON to file
+    if (serializeJson(doc, configFile) == 0) {
+      Serial.println(F("Failed to write to file"));
+      message = "Failed to write to file\r\n";
+    }
+
+    // Publish on MQTT
+    // char buffer[1024];// NOSONAR
+    // serializeJson(doc, buffer);
+    // client.publish(("Xlyric/sauvegarde/"+ node_id).c_str() ,0,true, buffer);
+
+    // Close the file
+    configFile.close();
+    return message;
   }
-
-  // Allocate a temporary JsonDocument
-  // Don't forget to change the capacity to match your requirements.
-  // Use arduinojson.org/assistant to compute the capacity.
-  JsonDocument doc;
-
-  // Set the values in the document
-  doc["hostname"] = hostname;
-  doc["port"] = port;
-  doc["Publish"] = Publish;
-  doc["IDXTemp"] = IDXTemp;
-  doc["maxtemp"] = maxtemp;
-  doc["IDXAlarme"] = IDXAlarme;
-  doc["IDX"] = IDX;  
-  doc["startingpow"] = startingpow;
-  doc["minpow"] = minpow;
-  doc["maxpow"] = maxpow;
-  doc["child"] = child;
-  doc["mode"] = mode;
-  doc["SubscribePV"] = SubscribePV;
-  doc["SubscribeTEMP"] = SubscribeTEMP;
-  doc["dimmer_on_off"] = dimmer_on_off;
-  doc["charge"] = charge;
-  doc["HA"] = HA;
-  doc["JEEDOM"] = JEEDOM;
-  doc["DOMOTICZ"] = DOMOTICZ;
-  doc["PVROUTER"] = PVROUTER;
-  doc["DALLAS"] = DALLAS;
-  doc["name"] = say_my_name;
-  doc["charge1"] = charge1;
-  doc["charge2"] = charge2;
-  doc["charge3"] = charge3;
-  doc["trigger"] = trigger;
-
-  // Serialize JSON to file
-  if (serializeJson(doc, configFile) == 0) {
-    Serial.println(F("Failed to write to file"));
-    message = "Failed to write to file\r\n";
-  }
-  
-  /// Publish on MQTT 
-  //char buffer[1024];// NOSONAR
-  //serializeJson(doc, buffer);
-  //client.publish(("Xlyric/sauvegarde/"+ node_id).c_str() ,0,true, buffer);
-  
-  // Close the file
-  configFile.close();
-  return message;
-}
 
   void calcul_charge() {
     charge = charge1 + charge2 + charge3;
@@ -272,14 +277,14 @@ String saveConfiguration() {
 
 };
 
-///// structure MQTT 
+///// structure MQTT
 
 struct Mqtt {
-  public:
-    const char *filename_mqtt = "/mqtt.json";
-    bool mqtt;
-    char username[64] = "mosquitto"; // NOSONAR
-    char password[64] = "mosquitto"; // NOSONAR
+public:
+  const char *filename_mqtt = "/mqtt.json";
+  bool mqtt;
+  char username[64] = "mosquitto";   // NOSONAR
+  char password[64] = "mosquitto";   // NOSONAR
 
   String loadmqtt() {
     // Open file for reading
@@ -298,7 +303,6 @@ struct Mqtt {
       return message = "Failed to read MQTT config\r\n";
     }
 
-    
     // Copy values from the JsonDocument to the Config
     String usernameValue = doc["MQTT_USER"].as<String>();
     strlcpy(username, usernameValue.c_str(), sizeof(username));
@@ -310,7 +314,7 @@ struct Mqtt {
 
     configFile.close();
 
-  return message;    
+    return message;
   }
 
   String savemqtt() {
@@ -320,9 +324,9 @@ struct Mqtt {
     if (!configFile) {
       Serial.println(F("Failed to open config file for writing in function Save configuration"));
       return "Failed to open config file for writing in function Save configuration\r\n";
-    } 
+    }
 
-      // Allocate a temporary JsonDocument
+    // Allocate a temporary JsonDocument
     // Don't forget to change the capacity to match your requirements.
     // Use arduinojson.org/assistant to compute the capacity.
     JsonDocument doc;
@@ -338,7 +342,7 @@ struct Mqtt {
 
     // Close the file
     configFile.close();
-    //config.restart = true; /// à voir si on rajoute pour reboot après config MQTT
+    // config.restart = true; /// à voir si on rajoute pour reboot après config MQTT
     return message;
   }
 
@@ -346,49 +350,49 @@ struct Mqtt {
 };
 
 struct Wifi_struct {
-  public:
-    char static_ip[16];
-    char static_sn[16];
-    char static_gw[16];
+public:
+  char static_ip[16];
+  char static_sn[16];
+  char static_gw[16];
 };
 
-///variables globales 
+/// variables globales
 struct System {
-/// @brief  température actuelle
-float celsius[MAX_DALLAS] = {0.00};
-/// @brief  puissance actuelle en %
-float puissance; 
-/// @brief  puissance actuelle en Watt
-int puissancewatt=0; 
-/// @brief  puissance max locale en Watt
-int puissancemax=0; 
-/// @brief  puissance dispo en watt
-int puissance_dispo=0;
+  /// @brief  température actuelle
+  float celsius[MAX_DALLAS] = {0.00};
+  /// @brief  puissance actuelle en %
+  float puissance;
+  /// @brief  puissance actuelle en Watt
+  int puissancewatt=0;
+  /// @brief  puissance max locale en Watt
+  int puissancemax=0;
+  /// @brief  puissance dispo en watt
+  int puissance_dispo=0;
 
-int change=0; 
-/// @brief état du ventilateur
-bool cooler=false;
-/// @brief  puissance cumulée en Watt (remonté par l'enfant toute les 10 secondes)
-int puissance_cumul=0;
-/// @brief etat de la surchauffe
-int dallas_maitre=0;
-/// @brief sonde principale
-byte security=0;
-/// @brief  état ping
-bool ping=false;
-const char pingurl[35] = "ota.apper-solaire.org";
-int pingfail=0;
+  int change=0;
+  /// @brief état du ventilateur
+  bool cooler=false;
+  /// @brief  puissance cumulée en Watt (remonté par l'enfant toute les 10 secondes)
+  int puissance_cumul=0;
+  /// @brief etat de la surchauffe
+  int dallas_maitre=0;
+  /// @brief sonde principale
+  byte security=0;
+  /// @brief  état ping
+  bool ping=false;
+  const char pingurl[35] = "ota.apper-solaire.org";
+  int pingfail=0;
 };
 
 struct epoc {
-  public:
-    int heure;
-    int minute;
-    int seconde;
-    int jour;
-    int mois;
-    int annee;
-    int weekday;
+public:
+  int heure;
+  int minute;
+  int seconde;
+  int jour;
+  int mois;
+  int annee;
+  int weekday;
 };
 
 

--- a/src/function/StreamConcat.h
+++ b/src/function/StreamConcat.h
@@ -3,33 +3,41 @@
 #include <Stream.h>
 
 class StreamConcat : public Stream {
-  public:
-    StreamConcat(Stream* s1, Stream* s2) : _s1(s1), _s2(s2) {}
+public:
+StreamConcat(Stream* s1, Stream* s2) : _s1(s1), _s2(s2) {
+}
 
-    size_t write(const uint8_t* p, size_t n) override { return 0; }
-    size_t write(uint8_t c) override { return 0; }
-    void flush() override {} //NOSONAR
+size_t write(const uint8_t* p, size_t n) override {
+  return 0;
+}
+size_t write(uint8_t c) override {
+  return 0;
+}
+void flush() override {
+}  // NOSONAR
 
-    int available() override { return _s1->available() + _s2->available(); }
+int available() override {
+  return _s1->available() + _s2->available();
+}
 
-    int read() override {
-      int c = _s1->read();
-      return c != -1 ? c : _s2->read();
-    }
+int read() override {
+  int c = _s1->read();
+  return c != -1 ? c : _s2->read();
+}
 
-    size_t readBytes(char* buffer, size_t length) override {
-      size_t count = _s1->readBytes(buffer, length);
-      if (count == 0)
-        count = _s2->readBytes(buffer, length);
-      return count;
-    }
+size_t readBytes(char* buffer, size_t length) override {
+  size_t count = _s1->readBytes(buffer, length);
+  if (count == 0)
+    count = _s2->readBytes(buffer, length);
+  return count;
+}
 
-    int peek() override {
-      int c = _s1->peek();
-      return c != -1 ? c : _s2->peek();
-    }
+int peek() override {
+  int c = _s1->peek();
+  return c != -1 ? c : _s2->peek();
+}
 
-  private:
-    Stream* _s1;
-    Stream* _s2;
+private:
+Stream* _s1;
+Stream* _s2;
 };

--- a/src/function/dimmer.h
+++ b/src/function/dimmer.h
@@ -1,7 +1,7 @@
 #ifndef DIMMER_FUNCTIONS
 #define DIMMER_FUNCTIONS
 
-///regroupement des fonctions de dimmer
+// regroupement des fonctions de dimmer
 
 #include <Arduino.h>
 #include "mqtt.h"
@@ -16,12 +16,12 @@
 #else
 // Web services
   #include <ESP8266WiFi.h>
-  //#include <ESPAsyncTCP.h>
-  #include <ESP8266HTTPClient.h> 
+// #include <ESPAsyncTCP.h>
+  #include <ESP8266HTTPClient.h>
 #endif
 
 extern struct System sysvar;
-extern struct Config config;  
+extern struct Config config;
 extern dimmerLamp dimmer;
 #ifdef outputPin2
 extern dimmerLamp dimmer2;

--- a/src/function/ha.h
+++ b/src/function/ha.h
@@ -9,187 +9,218 @@ extern Mqtt mqtt_config; // NOSONAR
 extern System sysvar;
 extern DeviceAddress addr[MAX_DALLAS];  // array of (up to) 15 temperature sensors
 extern String devAddrNames[MAX_DALLAS];  // array of (up to) 15 temperature sensors
-extern int deviceCount ; // nombre de sonde(s) dallas détectée(s)
+extern int deviceCount;  // nombre de sonde(s) dallas détectée(s)
 
 String stringBool(bool mybool);
 
 /// @brief déclaration des configurations HA et MQTT
 struct HA
 {
-    private:int MQTT_INTERVAL = 60;
-    /* MQTT */
-    private:String name="none"; 
-    public:void Set_name(String setter) {name=setter; }
+private: int MQTT_INTERVAL = 60;
+  /* MQTT */
+private: String name="none";
+public: void Set_name(String setter) {
+    name=setter;
+  }
 
-    private:String object_id; 
-    public:void Set_object_id(String setter) {object_id=setter; }
+private: String object_id;
+public: void Set_object_id(String setter) {
+    object_id=setter;
+  }
 
-    private:String dev_cla; 
-    public:void Set_dev_cla(String setter) {dev_cla=setter; }
+private: String dev_cla;
+public: void Set_dev_cla(String setter) {
+    dev_cla=setter;
+  }
 
-    private:String unit_of_meas; 
-    public:void Set_unit_of_meas(String setter) {unit_of_meas=setter; }
+private: String unit_of_meas;
+public: void Set_unit_of_meas(String setter) {
+    unit_of_meas=setter;
+  }
 
-    private:String stat_cla; 
-    public:void Set_stat_cla(String setter) {stat_cla=setter; }
+private: String stat_cla;
+public: void Set_stat_cla(String setter) {
+    stat_cla=setter;
+  }
 
-    private:String entity_category; 
-    public:void Set_entity_category(String setter) {entity_category=setter; }
-    
-    private:String entity_type="sensor"; 
-    public:void Set_entity_type(String setter) {entity_type=setter; }
+private: String entity_category;
+public: void Set_entity_category(String setter) {
+    entity_category=setter;
+  }
 
-    private:String icon; 
-    public:void Set_icon(String setter) {icon=R"("ic": ")" + setter + R"(",)"; }
-    //{icon="\"ic\": \""+ setter +"\", "; }
+private: String entity_type="sensor";
+public: void Set_entity_type(String setter) {
+    entity_type=setter;
+  }
 
-    private:String min; 
-    public:void Set_entity_valuemin(String setter) {min=setter; }
+private: String icon;
+public: void Set_icon(String setter) {
+    icon=R"("ic": ")" + setter + R"(",)";
+  }
+  // {icon="\"ic\": \""+ setter +"\", "; }
 
-    private:String max; 
-    public:void Set_entity_valuemax(String setter) {max=setter; }
+private: String min;
+public: void Set_entity_valuemin(String setter) {
+    min=setter;
+  }
 
-    private:String step; 
-    public:void Set_entity_valuestep(String setter) {step=setter; }
+private: String max;
+public: void Set_entity_valuemax(String setter) {
+    max=setter;
+  }
 
-    private:String entity_option; 
-    public:void Set_entity_option(String setter) {entity_option=setter; }
+private: String step;
+public: void Set_entity_valuestep(String setter) {
+    step=setter;
+  }
 
-    private:bool retain_flag; 
-    public:void Set_retain_flag(bool setter) {retain_flag=setter; }
+private: String entity_option;
+public: void Set_entity_option(String setter) {
+    entity_option=setter;
+  }
 
-    private:int qos; 
-    public:void Set_entity_qos(int setter) {qos=setter; }
+private: bool retain_flag;
+public: void Set_retain_flag(bool setter) {
+    retain_flag=setter;
+  }
 
-    private:String retain; 
-    public:void Set_retain(bool setter) {
+private: int qos;
+public: void Set_entity_qos(int setter) {
+    qos=setter;
+  }
+
+private: String retain;
+public: void Set_retain(bool setter) {
     if (setter) {retain="\"ret\":true,"; }
   }
 
-    private:String expire_after; 
-    public:void Set_expire_after(bool setter) {
-      if (setter) {expire_after=R"("exp_aft": ")" + String(MQTT_INTERVAL) + R"(", )"; }
+private: String expire_after;
+public: void Set_expire_after(bool setter) {
+    if (setter) {expire_after=R"("exp_aft": ")" + String(MQTT_INTERVAL) + R"(", )"; }
+  }
+
+private: String HA_sensor_type() {
+    String topic = "homeassistant/"+ entity_type +"/"+ node_id +"/";
+    String topic_Xlyric = "Xlyric/"+ node_id +"/";
+    String info;
+    if (entity_type == "sensor") {
+      info = "\"dev_cla\": \""+dev_cla+"\","
+             "\"unit_of_meas\": \""+unit_of_meas+"\","
+             "\"stat_cla\": \""+stat_cla+"\","
+             "\"value_template\": \"{{ value_json."+ object_id +" }}\",";
     }
-
-  private:String HA_sensor_type() {
-      String topic = "homeassistant/"+ entity_type +"/"+ node_id +"/";
-      String topic_Xlyric = "Xlyric/"+ node_id +"/";
-      String info;
-       if (entity_type == "sensor") {
-              info =         "\"dev_cla\": \""+dev_cla+"\","
-            "\"unit_of_meas\": \""+unit_of_meas+"\","
-            "\"stat_cla\": \""+stat_cla+"\"," 
-            "\"value_template\": \"{{ value_json."+ object_id +" }}\","; 
-      }
-      else if (entity_type == "switch") { 
-              info =         "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
-            "\"pl\":  \"{{ value_json."+ object_id +" }}\","
-            "\"pl_on\": \"{ \\\""+object_id+"\\\" : \\\"1\\\"  } \","
-            "\"pl_off\": \"{ \\\""+object_id+"\\\" : \\\"0\\\"  } \","
-            "\"stat_on\":1,"
-            "\"stat_off\":0,"
-          "\"qos\":1,"
-          "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\",";
-      } 
-      else if (entity_type == "number") { 
-            info =         "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
-          "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
-            "\"cmd_tpl\": \"{ \\\""+object_id+"\\\" : {{ value }} } \"," 
-          "\"entity_category\": \""+ entity_category + "\","
-          "\"max\": \""+max+"\","
-          "\"min\": \""+min+"\","
-          "\"step\": \""+step+"\",";
-      } 
-      else if (entity_type == "select") { 
-            info =         "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
-          "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
-            "\"cmd_tpl\": \"{ \\\""+object_id+"\\\" : \\\"{{ value }}\\\" } \"," 
-          "\"entity_category\": \""+ entity_category + "\","
-          "\"options\": ["+ entity_option + "],";
-      } 
-      else if (entity_type == "binary_sensor") { 
-              info =         "\"dev_cla\": \""+dev_cla+"\","
-            "\"pl_on\":\"true\","
-            "\"pl_off\":\"false\","
-            "\"val_tpl\": \"{{ value_json."+ object_id +" }}\",";
-      }
-      else if (entity_type == "button") { 
-            info =            "\"entity_category\": \""+ entity_category + "\","
-          "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
-            "\"pl_prs\": \"{ \\\""+object_id+"\\\" : \\\"1\\\"  } \",";
-      }
-      return info;
+    else if (entity_type == "switch") {
+      info = "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
+             "\"pl\":  \"{{ value_json."+ object_id +" }}\","
+             "\"pl_on\": \"{ \\\""+object_id+"\\\" : \\\"1\\\"  } \","
+             "\"pl_off\": \"{ \\\""+object_id+"\\\" : \\\"0\\\"  } \","
+             "\"stat_on\":1,"
+             "\"stat_off\":0,"
+             "\"qos\":1,"
+             "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\",";
     }
+    else if (entity_type == "number") {
+      info = "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
+             "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
+             "\"cmd_tpl\": \"{ \\\""+object_id+"\\\" : {{ value }} } \","
+             "\"entity_category\": \""+ entity_category + "\","
+             "\"max\": \""+max+"\","
+             "\"min\": \""+min+"\","
+             "\"step\": \""+step+"\",";
+    }
+    else if (entity_type == "select") {
+      info = "\"val_tpl\": \"{{ value_json."+ object_id +" }}\","
+             "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
+             "\"cmd_tpl\": \"{ \\\""+object_id+"\\\" : \\\"{{ value }}\\\" } \","
+             "\"entity_category\": \""+ entity_category + "\","
+             "\"options\": ["+ entity_option + "],";
+    }
+    else if (entity_type == "binary_sensor") {
+      info = "\"dev_cla\": \""+dev_cla+"\","
+             "\"pl_on\":\"true\","
+             "\"pl_off\":\"false\","
+             "\"val_tpl\": \"{{ value_json."+ object_id +" }}\",";
+    }
+    else if (entity_type == "button") {
+      info = "\"entity_category\": \""+ entity_category + "\","
+             "\"cmd_t\": \""+ topic_Xlyric + "command/" +  entity_type + "/" + object_id + "\","
+             "\"pl_prs\": \"{ \\\""+object_id+"\\\" : \\\"1\\\"  } \",";
+    }
+    return info;
+  }
 
 
 
-  private:String IPaddress = WiFi.localIP().toString();
-  
-    private:String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
-    // setter mod_mac
-    public:void Set_node_mac(String setter) {node_mac=setter; }
-       
-    private:String node_id = String("dimmer-") + node_mac; 
-    private:String topic_switch = "homeassistant/switch/"+ node_id +"/";
-    private:String topic_switch_state = "homeassistant/switch/";
-    private:String HA_device_declare() { 
-              String IPaddress = WiFi.localIP().toString();
-              String info = R"(
+private: String IPaddress = WiFi.localIP().toString();
+
+private: String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
+// setter mod_mac
+public: void Set_node_mac(String setter) {
+    node_mac=setter;
+  }
+
+private: String node_id = String("dimmer-") + node_mac;
+private: String topic_switch = "homeassistant/switch/"+ node_id +"/";
+private: String topic_switch_state = "homeassistant/switch/";
+private: String HA_device_declare() {
+    String IPaddress = WiFi.localIP().toString();
+    String info = R"(
                   "dev": {
                       "ids": ")" + node_id + R"(",
                       "name": ")" + node_id + R"(",
                       "sw": "Dimmer )" + String(VERSION) + R"(",
-                      "mdl": "ESP8266 )" + IPaddress + R"(",
+                      "mdl": "ESP8266 )" + IPaddress +
+                  R"(",
                       "mf": "Cyril Poissonnier",
                       "cu": "http://)" + IPaddress + R"("
                   }
               )";
-            return info;
-            }
+    return info;
+  }
 
 
-  public:void HA_discovery(){
+public: void HA_discovery(){
 
-      //protection contre les variables non définies
-      if (name == "none") {return; }
+    // protection contre les variables non définies
+    if (name == "none") {return; }
 
-      String topic = "homeassistant/"+ entity_type +"/"+ node_id +"/";
-      String topic_Xlyric = "Xlyric/"+ node_id +"/";
+    String topic = "homeassistant/"+ entity_type +"/"+ node_id +"/";
+    String topic_Xlyric = "Xlyric/"+ node_id +"/";
 
     String device = R"(
-        {
-            "name": ")" + name + R"(",
-            "obj_id": "dimmer-)" + object_id + "-" + node_mac + R"(",
-            "uniq_id": ")" + node_mac + "-" + object_id + R"(",
-            "stat_t": ")" + topic_Xlyric + "sensors/" + object_id + "/state" + R"(",
-            "avty_t": ")" + topic_Xlyric + "status\","
-            + HA_sensor_type()
-            + icon
-            + retain
-            + expire_after
-            + HA_device_declare() + 
-            "}";
+      {
+        "name": ")" + name + R"(",
+        "obj_id": "dimmer-)" + object_id + "-" + node_mac + R"(",
+        "uniq_id": ")" + node_mac + "-" + object_id + R"(",
+        "stat_t": ")" + topic_Xlyric + "sensors/" + object_id + "/state" + R"(",
+        "avty_t": ")" + topic_Xlyric + "status\","
+                    + HA_sensor_type()
+                    + icon
+                    + retain
+                    + expire_after
+                    + HA_device_declare() +
+                    "}";
 
-       if (strlen(object_id.c_str()) > 0) {
-       client.publish(String(topic+object_id+"/config").c_str(), device.c_str(),true); // déclaration autoconf dimmer
-       }  
-       else {
-        client.publish(String(topic+"config").c_str(), device.c_str(),true); // déclaration autoconf dimmer
-       }
- 
+    if (strlen(object_id.c_str()) > 0) {
+      client.publish(String(topic+object_id+"/config").c_str(), device.c_str(),true);  // déclaration autoconf dimmer
+    }
+    else {
+      client.publish(String(topic+"config").c_str(), device.c_str(),true);   // déclaration autoconf dimmer
     }
 
-    public:void send(String value){
+  }
+
+public: void send(String value){
     if (config.JEEDOM || config.HA) {
       String topic = "Xlyric/"+ node_id +"/sensors/";
       String message = "  { \""+object_id+"\" : \"" + value.c_str() + "\"  } ";
       client.publish(String(topic + object_id + "/state").c_str(), message.c_str(), retain_flag);
     }
-  } 
+  }
 };
 
 /// création des sensors
-HA device_dimmer; 
+HA device_dimmer;
 HA device_temp[MAX_DALLAS];  // NOSONAR
 HA device_temp_master;
 
@@ -202,7 +233,7 @@ HA device_dimmer_on_off;
 HA device_dimmer_save;
 
 /// création number
-HA device_dimmer_starting_pow; 
+HA device_dimmer_starting_pow;
 HA device_dimmer_maxtemp;
 HA device_dimmer_minpow;
 HA device_dimmer_maxpow;
@@ -216,17 +247,18 @@ HA device_dimmer_alarm_temp;
 HA device_cooler;
 HA device_dimmer_alarm_temp_clear;
 
-// creation remonté de puissance 
+// creation remonté de puissance
 HA device_dimmer_power;
 HA device_dimmer_total_power;
 
 void devices_init(){
-    /// création des sensors
+  /// création des sensors
   device_dimmer.Set_name("Puissance");
   device_dimmer.Set_object_id("power");
   device_dimmer.Set_unit_of_meas("%");
   device_dimmer.Set_stat_cla("measurement");
-  device_dimmer.Set_dev_cla("power_factor"); // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  device_dimmer.Set_dev_cla("power_factor");
   device_dimmer.Set_icon("mdi:percent");
   device_dimmer.Set_entity_type("sensor");
   device_dimmer.Set_retain_flag(true);
@@ -235,7 +267,8 @@ void devices_init(){
   device_dimmer_power.Set_object_id("watt");
   device_dimmer_power.Set_unit_of_meas("W");
   device_dimmer_power.Set_stat_cla("measurement");
-  device_dimmer_power.Set_dev_cla("power"); // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  device_dimmer_power.Set_dev_cla("power");
   device_dimmer_power.Set_icon("mdi:home-lightning-bolt-outline");
   device_dimmer_power.Set_entity_type("sensor");
   device_dimmer_power.Set_retain_flag(true);
@@ -244,32 +277,33 @@ void devices_init(){
   device_dimmer_total_power.Set_object_id("watt_total");
   device_dimmer_total_power.Set_unit_of_meas("W");
   device_dimmer_total_power.Set_stat_cla("measurement");
-  device_dimmer_total_power.Set_dev_cla("power"); // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  // fix is using native unit of measurement '%' which is not a valid unit for the device class ('power') it is using
+  device_dimmer_total_power.Set_dev_cla("power");
   device_dimmer_total_power.Set_icon("mdi:home-lightning-bolt-outline");
   device_dimmer_total_power.Set_entity_type("sensor");
   device_dimmer_total_power.Set_retain_flag(true);
 
 
-    for (int i = 0; i < deviceCount; i++) {
-      device_temp[i].Set_name("Température" + String(i+1) );
-      device_temp[i].Set_object_id("temperature_"+ devAddrNames[i]);
-      device_temp[i].Set_unit_of_meas("°C");
-      device_temp[i].Set_stat_cla("measurement");
-      device_temp[i].Set_dev_cla("temperature");
-      device_temp[i].Set_entity_type("sensor");
-      device_temp[i].Set_entity_qos(1);
-      device_temp[i].Set_retain_flag(true);
-    }
- /// temp master 
-      device_temp_master.Set_name("Température master");
-      device_temp_master.Set_object_id("temperature");
-      device_temp_master.Set_unit_of_meas("°C");
-      device_temp_master.Set_stat_cla("measurement");
-      device_temp_master.Set_dev_cla("temperature");
-      device_temp_master.Set_entity_type("sensor");
-      device_temp_master.Set_entity_qos(1);
-      device_temp_master.Set_retain_flag(true);
-  
+  for (int i = 0; i < deviceCount; i++) {
+    device_temp[i].Set_name("Température" + String(i+1) );
+    device_temp[i].Set_object_id("temperature_"+ devAddrNames[i]);
+    device_temp[i].Set_unit_of_meas("°C");
+    device_temp[i].Set_stat_cla("measurement");
+    device_temp[i].Set_dev_cla("temperature");
+    device_temp[i].Set_entity_type("sensor");
+    device_temp[i].Set_entity_qos(1);
+    device_temp[i].Set_retain_flag(true);
+  }
+  /// temp master
+  device_temp_master.Set_name("Température master");
+  device_temp_master.Set_object_id("temperature");
+  device_temp_master.Set_unit_of_meas("°C");
+  device_temp_master.Set_stat_cla("measurement");
+  device_temp_master.Set_dev_cla("temperature");
+  device_temp_master.Set_entity_type("sensor");
+  device_temp_master.Set_entity_qos(1);
+  device_temp_master.Set_retain_flag(true);
+
   /// création des switch
   device_relay1.Set_name("Relais 1");
   device_relay1.Set_object_id("relay1");
@@ -285,7 +319,7 @@ void devices_init(){
   device_dimmer_on_off.Set_object_id("on_off");
   device_dimmer_on_off.Set_entity_type("switch");
   device_dimmer_on_off.Set_retain_flag(true);
- 
+
   /// création des button
   device_dimmer_save.Set_name("Sauvegarder");
   device_dimmer_save.Set_object_id("save");
@@ -299,7 +333,7 @@ void devices_init(){
   device_dimmer_starting_pow.Set_entity_type("number");
   device_dimmer_starting_pow.Set_entity_category("config");
   device_dimmer_starting_pow.Set_entity_valuemin("-100");
-  device_dimmer_starting_pow.Set_entity_valuemax("500"); 
+  device_dimmer_starting_pow.Set_entity_valuemax("500");
   device_dimmer_starting_pow.Set_entity_valuestep("1");
   device_dimmer_starting_pow.Set_retain_flag(true);
 
@@ -308,7 +342,7 @@ void devices_init(){
   device_dimmer_minpow.Set_entity_type("number");
   device_dimmer_minpow.Set_entity_category("config");
   device_dimmer_minpow.Set_entity_valuemin("0");
-  device_dimmer_minpow.Set_entity_valuemax("100"); 
+  device_dimmer_minpow.Set_entity_valuemax("100");
   device_dimmer_minpow.Set_entity_valuestep("1");
   device_dimmer_minpow.Set_retain_flag(true);
 
@@ -317,7 +351,7 @@ void devices_init(){
   device_dimmer_maxpow.Set_entity_type("number");
   device_dimmer_maxpow.Set_entity_category("config");
   device_dimmer_maxpow.Set_entity_valuemin("0");
-  device_dimmer_maxpow.Set_entity_valuemax("100"); 
+  device_dimmer_maxpow.Set_entity_valuemax("100");
   device_dimmer_maxpow.Set_entity_valuestep("1");
   device_dimmer_maxpow.Set_retain_flag(true);
 
@@ -326,7 +360,7 @@ void devices_init(){
   device_dimmer_send_power.Set_entity_type("number");
   device_dimmer_send_power.Set_entity_category("config");
   device_dimmer_send_power.Set_entity_valuemin("0");
-  device_dimmer_send_power.Set_entity_valuemax("100"); 
+  device_dimmer_send_power.Set_entity_valuemax("100");
   device_dimmer_send_power.Set_entity_valuestep("1");
   device_dimmer_send_power.Set_retain_flag(true);
 
@@ -335,7 +369,7 @@ void devices_init(){
   device_dimmer_maxtemp.Set_entity_type("number");
   device_dimmer_maxtemp.Set_entity_category("config");
   device_dimmer_maxtemp.Set_entity_valuemin("0");
-  device_dimmer_maxtemp.Set_entity_valuemax("75"); 
+  device_dimmer_maxtemp.Set_entity_valuemax("75");
   device_dimmer_maxtemp.Set_entity_valuestep("1");
   device_dimmer_maxtemp.Set_retain_flag(true);
 
@@ -371,51 +405,51 @@ void devices_init(){
 }
 
 void HA_discover(){
-  if (config.HA){
-          Serial.println("HA discovery" );
-        /// création des binary_sensor et enregistrement sous HA  
-        device_dimmer_on_off.HA_discovery();
-        device_dimmer_on_off.send(String(config.dimmer_on_off));
+  if (config.HA) {
+    Serial.println("HA discovery" );
+    /// création des binary_sensor et enregistrement sous HA
+    device_dimmer_on_off.HA_discovery();
+    device_dimmer_on_off.send(String(config.dimmer_on_off));
 
-        device_dimmer.HA_discovery();
-        device_dimmer.send(String(sysvar.puissance));
+    device_dimmer.HA_discovery();
+    device_dimmer.send(String(sysvar.puissance));
 
-        device_dimmer_power.HA_discovery();
-        device_dimmer_power.send(String(sysvar.puissance* config.charge/100));
+    device_dimmer_power.HA_discovery();
+    device_dimmer_power.send(String(sysvar.puissance* config.charge/100));
 
-        device_dimmer_total_power.HA_discovery();
-        device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));
+    device_dimmer_total_power.HA_discovery();
+    device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));
 
-        device_cooler.HA_discovery();
-        device_cooler.send(stringBool(false));
+    device_cooler.HA_discovery();
+    device_cooler.send(stringBool(false));
 
-        device_temp_master.HA_discovery(); // discovery fait à la 1ere réception sonde ou mqtt.
-        device_temp_master.send(String(0));
+    device_temp_master.HA_discovery();  // discovery fait à la 1ere réception sonde ou mqtt.
+    device_temp_master.send(String(0));
 
-        #ifdef RELAY1
-          device_relay1.HA_discovery();
-          device_relay1.send(String(0));
-        #endif
-        #ifdef RELAY2
-          device_relay2.HA_discovery();
-          device_relay2.send(String(0));
-        #endif
-        device_dimmer_starting_pow.HA_discovery();
-        device_dimmer_starting_pow.send(String(config.startingpow));
+    #ifdef RELAY1
+    device_relay1.HA_discovery();
+    device_relay1.send(String(0));
+    #endif
+    #ifdef RELAY2
+    device_relay2.HA_discovery();
+    device_relay2.send(String(0));
+    #endif
+    device_dimmer_starting_pow.HA_discovery();
+    device_dimmer_starting_pow.send(String(config.startingpow));
 
-        device_dimmer_minpow.HA_discovery();
-        device_dimmer_minpow.send(String(config.minpow));
+    device_dimmer_minpow.HA_discovery();
+    device_dimmer_minpow.send(String(config.minpow));
 
-        device_dimmer_maxpow.HA_discovery();
-        device_dimmer_maxpow.send(String(config.maxpow));
+    device_dimmer_maxpow.HA_discovery();
+    device_dimmer_maxpow.send(String(config.maxpow));
 
-        device_dimmer_send_power.HA_discovery();
-        device_dimmer_send_power.send(String(sysvar.puissance));
+    device_dimmer_send_power.HA_discovery();
+    device_dimmer_send_power.send(String(sysvar.puissance));
 
-        device_dimmer_child_mode.HA_discovery();
-        device_dimmer_child_mode.send(String(config.mode));
+    device_dimmer_child_mode.HA_discovery();
+    device_dimmer_child_mode.send(String(config.mode));
 
-        device_dimmer_save.HA_discovery();
-        }
+    device_dimmer_save.HA_discovery();
+  }
 }
 #endif

--- a/src/function/jotta.h
+++ b/src/function/jotta.h
@@ -7,100 +7,93 @@
 /// code des tests SSR non random
 #ifdef SSR_ZC
 
-    struct SSR_BURST
-    {
-      /* data */
-      public:char sequence_result[102];// NOSONAR
-      private:int power;
+struct SSR_BURST {
+/* data */
+public: char sequence_result[102];     // NOSONAR
+private: int power;
 
-      // getter puissance 
-      public:int get_power(){
-        return power;
-      }
+// getter puissance
+public: int get_power(){
+    return power;
+  }
 
-      //setter puissance 
-      public:void set_power(int power){
-        this->power = power;
-        calcul(power);
-      }
+// setter puissance
+public: void set_power(int power){
+    this->power = power;
+    calcul(power);
+  }
 
-      public:
-      void calcul(int puissance)
-      {
-        double decimalValue; 
-        decimalValue = round(puissance * 100) / 10000; // Arrondir à 2 décimales
-        int denominator = 100; // Choisissez une valeur de dénominateur appropriée
+public:
+  void calcul(int puissance) {
+    double decimalValue;
+    decimalValue = round(puissance * 100) / 10000;     // Arrondir à 2 décimales
+    int denominator = 100;     // Choisissez une valeur de dénominateur appropriée
 
-        int numerator = decimalValue * denominator;
-        int gcdValue = gcd(numerator, denominator);
+    int numerator = decimalValue * denominator;
+    int gcdValue = gcd(numerator, denominator);
 
-        numerator /= gcdValue;
-        denominator /= gcdValue;
+    numerator /= gcdValue;
+    denominator /= gcdValue;
 
-        //Serial.print(decimalValue, 2); // Affichez le nombre décimal avec 4 décimales
-        Serial.print("en fraction : ");
-        Serial.print(numerator);
-        Serial.print("/");
-        Serial.print(denominator);
-        
-        float sequence = float(denominator) / float(numerator) ;
-        Serial.print(" Sequence : ");
-        Serial.println(sequence);
-        // boucle de 100 occurences
-        action_sequence(sequence);
-      }
+    // Serial.print(decimalValue, 2); // Affichez le nombre décimal avec 4 décimales
+    Serial.print("en fraction : ");
+    Serial.print(numerator);
+    Serial.print("/");
+    Serial.print(denominator);
 
-    /// @brief  fonction de calcul de la séquence d'ouverture et fermeture du SSR 
-    /// @param sequence 
-    /// @return 
-      private:void action_sequence(float sequence) {
-        float boucle = sequence;
-        
-        for (int j = 1; j < 101; j++) {
-          if (j >= boucle) {
-            sequence_result[j - 1] = '+';
-            boucle = boucle + sequence;
-          } else {
-            sequence_result[j - 1] = '-';
+    float sequence = float(denominator) / float(numerator);
+    Serial.print(" Sequence : ");
+    Serial.println(sequence);
+    // boucle de 100 occurences
+    action_sequence(sequence);
+  }
 
-          }
-        }
-        
-        sequence_result[101] = '\0'; // Terminer la chaîne avec un caractère nul
+/// @brief  fonction de calcul de la séquence d'ouverture et fermeture du SSR
+/// @param sequence
+/// @return
+private: void action_sequence(float sequence) {
+    float boucle = sequence;
 
-      }
-
-    /// @brief  fonction de calcul du plus grand diviseur commun
-      private:int gcd(int a, int b) {
-        if (b == 0) {
-          return a;
-        }
-        return gcd(b, a % b);
-      } 
-
-    };
-
-
-    int sequence_timer = 0;
-
-    extern SSR_BURST ssr_burst;
-
-    void SSR_run(){
-      if (ssr_burst.sequence_result[sequence_timer] == '+') {
-        digitalWrite(JOTTA, HIGH);
+    for (int j = 1; j < 101; j++) {
+      if (j >= boucle) {
+        sequence_result[j - 1] = '+';
+        boucle = boucle + sequence;
       } else {
-        digitalWrite(JOTTA, LOW);
+        sequence_result[j - 1] = '-';
       }
-
-      sequence_timer++;
-
-      if (sequence_timer == 100) {
-        sequence_timer = 0;
-      }
-
     }
-#endif 
-  // Configuration de la broche comme sortie
+    sequence_result[101] = '\0';     // Terminer la chaîne avec un caractère nul
+  }
+
+/// @brief  fonction de calcul du plus grand diviseur commun
+private: int gcd(int a, int b) {
+    if (b == 0) {
+      return a;
+    }
+    return gcd(b, a % b);
+  }
+};
+
+
+int sequence_timer = 0;
+
+extern SSR_BURST ssr_burst;
+
+void SSR_run() {
+  if (ssr_burst.sequence_result[sequence_timer] == '+') {
+    digitalWrite(JOTTA, HIGH);
+  } else {
+    digitalWrite(JOTTA, LOW);
+  }
+
+  sequence_timer++;
+
+  if (sequence_timer == 100) {
+    sequence_timer = 0;
+  }
+}
+#endif
+// Configuration de la broche comme sortie
 
 int time_sync = 0;  // Variable utilisée pour stocker le temps  // NOSONAR
 int frequency = 0;  // Variable utilisée pour stocker la fréquence du réseau // NOSONAR
@@ -109,60 +102,49 @@ int jotta_pow = 0;  // Variable utilisée pour stocker la commande de dimmer // 
 int avance_phase = 20;  // Variable utilisée pour stocker l'avance de phase // NOSONAR
 
 // 15 perfect pour moi, mais pour titi faut test 20
-//>13
-//<17
-//volatile bool topDepart = false;  // Variable volatile utilisée comme indicateur de top départ
+// >13
+// <17
+// volatile bool topDepart = false;  // Variable volatile utilisée comme indicateur de top départ
 
 
 
-IRAM_ATTR void jotta_run(){
+IRAM_ATTR void jotta_run() {
   #ifdef  SSR
-
-      time_sync = 0;
-
-      
+  time_sync = 0;
   #endif
-
 }
 
 
-constexpr int timeoutPinjotta = 498; // 100 us 
-IRAM_ATTR void jotta_ISR()
-{
-
-  frequency = 100 - avance_phase; 
-  time_tempo = 100- jotta_pow - avance_phase; 
+constexpr int timeoutPinjotta = 498; // 100 us
+IRAM_ATTR void jotta_ISR() {
+  frequency = 100 - avance_phase;
+  time_tempo = 100- jotta_pow - avance_phase;
   #ifdef  SSR
-  if (jotta_pow == 0 ){  
+  if (jotta_pow == 0 ) {
     digitalWrite(JOTTA, LOW);
-
     return;
   }
-  
-  if (time_sync == 100 - avance_phase){  
-    digitalWrite(JOTTA, LOW);
 
+  if (time_sync == 100 - avance_phase) {
+    digitalWrite(JOTTA, LOW);
     return;
   }
-  else if (time_sync >= (100-jotta_pow - avance_phase)){  
+  else if (time_sync >= (100-jotta_pow - avance_phase)) {
     digitalWrite(JOTTA, HIGH);
-
   }
 
+  if (digitalRead(JOTTA)) {    time_tempo++;  }
 
-  if (digitalRead(JOTTA)) {    time_tempo ++;  }
-
-  time_sync ++;
+  time_sync++;
 
   #endif
 }
 
-void timer_init()
-{
+void timer_init() {
   #ifdef  SSR
-	timer1_attachInterrupt(jotta_ISR);
-	timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
-	timer1_write(timeoutPinjotta); //100 us
+  timer1_attachInterrupt(jotta_ISR);
+  timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
+  timer1_write(timeoutPinjotta); // 100 us
   Serial.println("timer_init");
   #endif
 }
@@ -180,9 +162,7 @@ void init_jotta() {
 void jotta_command(int command) {
   #ifdef  SSR
   jotta_pow = command;
-  
-
-   #endif
+  #endif
 }
 
 #endif

--- a/src/function/littlefs.h
+++ b/src/function/littlefs.h
@@ -12,7 +12,7 @@
 #if defined(ESP32) || defined(ESP32ETH)
   #include <FS.h>
   #include "SPIFFS.h"
-  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct? 
+  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct?
 #else
   #include <LittleFS.h> // NOSONAR
 #endif
@@ -22,17 +22,17 @@ constexpr const char *wifi_conf = "/wifi.json";
 constexpr const char *programme_conf = "/programme.json";
 
 
-extern Config config;  //NOSONAR
+extern Config config;  // NOSONAR
 
-extern Logs logging; 
+extern Logs logging;
 
-extern String node_id; 
-extern Wifi_struct  wifi_config_fixe; //NOSONAR 
+extern String node_id;
+extern Wifi_struct wifi_config_fixe;  // NOSONAR
 
-//flag for saving data
-extern bool shouldSaveConfig ;  //NOSONAR
+// flag for saving data
+extern bool shouldSaveConfig;   // NOSONAR
 
-//callback notifying us of the need to save config
+// callback notifying us of the need to save config
 void saveConfigCallback () {
   Serial.println("Should save config");
   shouldSaveConfig = true;
@@ -41,7 +41,11 @@ void saveConfigCallback () {
 String loguptime(String log) {
   String uptime_stamp;
   uptime::calculateUptime();
-  uptime_stamp = String(uptime::getDays())+":"+String(uptime::getHours())+":"+String(uptime::getMinutes())+":"+String(uptime::getSeconds())+ "\t"+log +"\r\n";
+  uptime_stamp = String(uptime::getDays())
+                 +":"+String(uptime::getHours())
+                 +":"+String(uptime::getMinutes())
+                 +":"+String(uptime::getSeconds())
+                 +"\t"+ log +"\r\n";
   return uptime_stamp;
 }
 
@@ -50,53 +54,53 @@ String loguptime(String log) {
 //************* Gestion de la configuration - Lecture du fichier de configuration
 //***********************************
 
-//////////////wifi ip fixe 
+////////////// wifi ip fixe
 
 bool loadwifiIP(const char *wifi_conf, Wifi_struct &wifi_config_fixe) {
   // Open file for reading
   File configFile = LittleFS.open(wifi_conf, "r");
 
-      // Allocate a temporary JsonDocument
-      // Don't forget to change the capacity to match your requirements.
-      // Use arduinojson.org/v6/assistant to compute the capacity.
-      JsonDocument doc;
+  // Allocate a temporary JsonDocument
+  // Don't forget to change the capacity to match your requirements.
+  // Use arduinojson.org/v6/assistant to compute the capacity.
+  JsonDocument doc;
 
-      // Deserialize the JSON document
-      DeserializationError error = deserializeJson(doc, configFile);
-      if (error) {
-        Serial.println(F("Failed to read wifi config"));
-      }
+  // Deserialize the JSON document
+  DeserializationError error = deserializeJson(doc, configFile);
+  if (error) {
+    Serial.println(F("Failed to read wifi config"));
+  }
 
-      
-      // Copy values from the JsonDocument to the Config
-      
-      strlcpy(wifi_config_fixe.static_ip,                  // <- destination
-              doc["IP"] | "", // <- source
-              sizeof(wifi_config_fixe.static_ip));         // <- destination's capacity
-      
-      strlcpy(wifi_config_fixe.static_sn,                  // <- destination
-              doc["mask"] | "255.255.255.0", // <- source
-              sizeof(wifi_config_fixe.static_sn));         // <- destination's capacity
 
-      strlcpy(wifi_config_fixe.static_gw,                  // <- destination
-              doc["gateway"] | "192.168.1.254", // <- source
-              sizeof(wifi_config_fixe.static_gw));         // <- destination's capacity
+  // Copy values from the JsonDocument to the Config
 
-      configFile.close();
+  strlcpy(wifi_config_fixe.static_ip,                      // <- destination
+          doc["IP"] | "",                                  // <- source
+          sizeof(wifi_config_fixe.static_ip));             // <- destination's capacity
 
-return true;    
+  strlcpy(wifi_config_fixe.static_sn,                      // <- destination
+          doc["mask"] | "255.255.255.0",                   // <- source
+          sizeof(wifi_config_fixe.static_sn));             // <- destination's capacity
+
+  strlcpy(wifi_config_fixe.static_gw,                      // <- destination
+          doc["gateway"] | "192.168.1.254",                // <- source
+          sizeof(wifi_config_fixe.static_gw));             // <- destination's capacity
+
+  configFile.close();
+
+  return true;
 }
 
 void savewifiIP(const char *wifi_conf, Wifi_struct &wifi_config_fixe) {
-  
+
   // Open file for writing
-   File configFile = LittleFS.open(wifi_conf, "w");
+  File configFile = LittleFS.open(wifi_conf, "w");
   if (!configFile) {
     Serial.println(F("Failed to open config file for writing in function Save configuration"));
     return;
-  } 
+  }
 
-    // Allocate a temporary JsonDocument
+  // Allocate a temporary JsonDocument
   // Don't forget to change the capacity to match your requirements.
   // Use arduinojson.org/assistant to compute the capacity.
   JsonDocument doc;
@@ -126,9 +130,9 @@ bool test_fs_version() {
     logging.Set_log_init("FS version is missing please update or reboot for activate after ota\r\n");
     return false;
   }
-   // comparaison entre le contenu du fichier et la version du code FS_RELEASE
+  // comparaison entre le contenu du fichier et la version du code FS_RELEASE
   String version = file.readStringUntil('\n');
-  file.close(); 
+  file.close();
   if (version.toInt() < String(FS_RELEASE).toInt() )  {
     logging.Set_log_init(FS_version_is_not_same);
     return false;

--- a/src/function/minuteur.h
+++ b/src/function/minuteur.h
@@ -9,7 +9,7 @@
 #if defined(ESP32) || defined(ESP32ETH)
   #include <FS.h>
   #include "SPIFFS.h"
-  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct? 
+  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct?
 #else
   #include <LittleFS.h> // NOSONAR
 #endif
@@ -19,237 +19,237 @@
 
 extern System sysvar;
 extern Config config;
-extern gestion_puissance unified_dimmer; 
+extern gestion_puissance unified_dimmer;
 
 struct tm timeinfo;
-epoc actual_time; 
+epoc actual_time;
 
-/// @brief ///////init du NTP 
+/// @brief /////// init du NTP
 void ntpinit() {
-      // Configurer le serveur NTP et le fuseau horaire
-  configTzTime("CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00", NTP_SERVER);  //Voir Time-Zone: https://sites.google.com/a/usapiens.com/opnode/time-zones
+  // Configurer le serveur NTP et le fuseau horaire
+  // Voir Time-Zone: https://sites.google.com/a/usapiens.com/opnode/time-zones
+  configTzTime("CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00", NTP_SERVER);
   getLocalTime( &timeinfo );
   Serial.println(asctime(&timeinfo));
-  
+
 }
 
-//////// structure pour les programmateurs. 
+//////// structure pour les programmateurs.
 struct Programme {
-  public: 
-    char heure_demarrage[6];// NOSONAR
-    char heure_arret[6];// NOSONAR
-    int temperature=50;
-    bool run; 
-    int heure;
-    int minute;
-    
-    int seuil_start;
-    int seuil_stop;
-    int seuil_temperature;
-    int puissance=100;
+public:
+  char heure_demarrage[6];  // NOSONAR
+  char heure_arret[6];  // NOSONAR
+  int temperature=50;
+  bool run;
+  int heure;
+  int minute;
 
-  private:
-    bool security = false;
-    String name;
+  int seuil_start;
+  int seuil_stop;
+  int seuil_temperature;
+  int puissance=100;
 
-    /// setter pour le nom du programme
-    public:void set_name(String name) {
-      this->name = name;
+private:
+  bool security = false;
+  String name;
+
+/// setter pour le nom du programme
+public: void set_name(String name) {
+    this->name = name;
+  }
+
+
+/// @brief sauvegarde
+/// @param programme_conf
+public: void saveProgramme() {
+    const char * c_file = name.c_str();    // NOSONAR
+    JsonDocument doc;
+
+    //// vérification cohérence des données
+    if (check_data(heure_demarrage)) {strcpy(heure_demarrage, "00:00"); }
+    if (check_data(heure_arret)) {strcpy(heure_arret, "00:00"); }
+
+    // Set the values in the document
+    doc["heure_demarrage"] = heure_demarrage;
+    doc["heure_arret"] = heure_arret;
+    doc["temperature"] = temperature;
+    doc["seuil_start"] = seuil_start;
+    doc["seuil_stop"] = seuil_stop;
+    doc["seuil_temperature"] = seuil_temperature;
+    doc["puissance"] = puissance;
+
+    // Open file for writing
+    File configFile = LittleFS.open(c_file, "w");
+    if (!configFile) {
+      Serial.println(F("Failed to open config file for writing"));
+      return;
     }
 
-
-  /// @brief sauvegarde
-  /// @param programme_conf 
-  public:void saveProgramme() {
-        const char * c_file = name.c_str();// NOSONAR
-        JsonDocument doc;
-
-      ////vérification cohérence des données
-      if (check_data(heure_demarrage)) {strcpy(heure_demarrage, "00:00"); }
-      if (check_data(heure_arret)) {strcpy(heure_arret, "00:00"); }
-      
-        // Set the values in the document
-        doc["heure_demarrage"] = heure_demarrage;
-        doc["heure_arret"] = heure_arret;
-        doc["temperature"] = temperature;
-        doc["seuil_start"] = seuil_start;
-        doc["seuil_stop"] = seuil_stop;
-        doc["seuil_temperature"] = seuil_temperature;
-        doc["puissance"] = puissance;
-                
-          // Open file for writing
-        File configFile = LittleFS.open(c_file, "w");
-        if (!configFile) {
-          Serial.println(F("Failed to open config file for writing"));
-          return;
-        }
-
-        // Serialize JSON to file
-        if (serializeJson(doc, configFile) == 0) {
-          Serial.println(F("Failed to write to file"));
-        }
-        
-        configFile.close();
+    // Serialize JSON to file
+    if (serializeJson(doc, configFile) == 0) {
+      Serial.println(F("Failed to write to file"));
+    }
+    configFile.close();
   }
 
   /// @brief chargement
-  /// @param programme_conf 
-  
+  /// @param programme_conf
 
-  public:bool loadProgramme() {
-        const char * c_file = name.c_str();// NOSONAR
-        File configFile = LittleFS.open(c_file, "r");
 
-        // Allocate a temporary JsonDocument
-        // Don't forget to change the capacity to match your requirements.
-        // Use arduinojson.org/v6/assistant to compute the capacity.
-        JsonDocument doc;
+public: bool loadProgramme() {
+    const char * c_file = name.c_str();    // NOSONAR
+    File configFile = LittleFS.open(c_file, "r");
 
-        // Deserialize the JSON document
-        DeserializationError error = deserializeJson(doc, configFile);
-        if (error) {
-          Serial.println(F("Failed to read minuterie config "));
-          return false;
-        }
-      
-        strlcpy(heure_demarrage,                  // <- destination
-                doc["heure_demarrage"] | "00:00", // <- source
-                sizeof(heure_demarrage));         // <- destination's capacity
-        
-        strlcpy(heure_arret,                  // <- destination
-                doc["heure_arret"] | "00:00", // <- source
-                sizeof(heure_arret));         // <- destination's capacity
-        temperature = doc["temperature"] | 50 ; /// defaut à 50 °
-        seuil_start = doc["seuil_start"] | 0 ; /// defaut à 0 %°
-        seuil_stop = doc["seuil_stop"] | 0 ; /// defaut à sans arret %
-        seuil_temperature = doc["seuil_temperature"] | 0 ; /// defaut à 0 °
-        puissance = doc["puissance"] | 100 ; /// defaut à 100 %
+    // Allocate a temporary JsonDocument
+    // Don't forget to change the capacity to match your requirements.
+    // Use arduinojson.org/v6/assistant to compute the capacity.
+    JsonDocument doc;
 
-        configFile.close();
-      return true;    
+    // Deserialize the JSON document
+    DeserializationError error = deserializeJson(doc, configFile);
+    if (error) {
+      Serial.println(F("Failed to read minuterie config "));
+      return false;
+    }
+
+    strlcpy(heure_demarrage,                           // <- destination
+            doc["heure_demarrage"] | "00:00",          // <- source
+            sizeof(heure_demarrage));                  // <- destination's capacity
+
+    strlcpy(heure_arret,                               // <- destination
+            doc["heure_arret"] | "00:00",              // <- source
+            sizeof(heure_arret));                      // <- destination's capacity
+    temperature = doc["temperature"] | 50;             // defaut à 50 °
+    seuil_start = doc["seuil_start"] | 0;              // defaut à 0 %°
+    seuil_stop = doc["seuil_stop"] | 0;                // defaut à sans arret %
+    seuil_temperature = doc["seuil_temperature"] | 0;  // defaut à 0 °
+    puissance = doc["puissance"] | 100;                // defaut à 100 %
+
+    configFile.close();
+    return true;
   }
 
- void commande_run(){
-        run=true; 
+  void commande_run(){
+    run=true;
 
   }
 
-bool start_progr() {
-  /// test de la sécurité avant relance
-  if (security && ( sysvar.celsius[sysvar.dallas_maitre]> float(temperature*0.95) ) )  { return false; }
-  security = false;
+  bool start_progr() {
+    /// test de la sécurité avant relance
+    if (security && ( sysvar.celsius[sysvar.dallas_maitre]> float(temperature*0.95) ) )  { return false; }
+    security = false;
 
-  int heures;
-  int minutes;
+    int heures;
+    int minutes;
 
-  sscanf(heure_demarrage, "%d:%d", &heures, &minutes);
+    sscanf(heure_demarrage, "%d:%d", &heures, &minutes);
 
-  int heures_fin;
-  int minutes_fin;
+    int heures_fin;
+    int minutes_fin;
 
-  sscanf(heure_arret, "%d:%d", &heures_fin, &minutes_fin);
+    sscanf(heure_arret, "%d:%d", &heures_fin, &minutes_fin);
 
-  // si heure_demarrage == heure_arret alors on retourne false ( correction du bug si pas de programmation)
-  if (strcmp(heure_demarrage, heure_arret) == 0) {
-        return false;
-  }
-      
-  if(getLocalTime(&timeinfo)) {
-    if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min && sysvar.celsius[sysvar.dallas_maitre]< temperature ) { // correction bug #19  
+    // si heure_demarrage == heure_arret alors on retourne false ( correction du bug si pas de programmation)
+    if (strcmp(heure_demarrage, heure_arret) == 0) {
+      return false;
+    }
+
+    if(getLocalTime(&timeinfo)) {
+      if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min &&
+          sysvar.celsius[sysvar.dallas_maitre]< temperature ) {  // correction bug #19
         commande_run();
-        return true; 
+        return true;
+      }
     }
-  }
 
-  // remise en route en cas de reboot et si l'heure est dépassée  
-  // recherche si l'heure est passée 
-  bool heure_passee = false;
-  if (timeinfo.tm_hour > heures || (timeinfo.tm_hour == heures && timeinfo.tm_min > minutes )) {
-                       heure_passee = true; 
-  }
-  // recherche si l'heure d'arret est est passée
-  bool heure_arret_passee = false;
-  if (timeinfo.tm_hour > heures_fin || (timeinfo.tm_hour == heures_fin && timeinfo.tm_min >= minutes_fin )) {
-                       heure_arret_passee = true; 
-  }
-
-
-  if (heure_passee && !heure_arret_passee && sysvar.celsius[sysvar.dallas_maitre]< temperature ) {
-           commande_run();
-            return true; 
-  }
-
-
-return false; 
-}
-
-bool stop_progr() {
-  int heures;
-  int minutes;
-  /// sécurité temp
-  if ( sysvar.celsius[sysvar.dallas_maitre]>= temperature ) { 
-    run=false; 
-    security = true;
-     // protection flicking
-    sscanf(heure_demarrage, "%d:%d", &heures, &minutes);  
-
-    if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min) {
-      delay(15000);
+    // remise en route en cas de reboot et si l'heure est dépassée
+    // recherche si l'heure est passée
+    bool heure_passee = false;
+    if (timeinfo.tm_hour > heures || (timeinfo.tm_hour == heures && timeinfo.tm_min > minutes )) {
+      heure_passee = true;
     }
-  return true; 
-  }
-
-  sscanf(heure_arret, "%d:%d", &heures, &minutes);
-
-
-
-  if(getLocalTime(&timeinfo)) {
-    if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min) {
-        run=false; 
-        return true; 
+    // recherche si l'heure d'arret est est passée
+    bool heure_arret_passee = false;
+    if (timeinfo.tm_hour > heures_fin || (timeinfo.tm_hour == heures_fin && timeinfo.tm_min >= minutes_fin )) {
+      heure_arret_passee = true;
     }
-  }
-  return false; 
-}
-    /// démarrage si le seuil est atteint 
-  bool start_seuil() {
-    if ( unified_dimmer.get_power() >= seuil_start && sysvar.celsius[sysvar.dallas_maitre]< seuil_temperature && seuil_start != seuil_stop) { 
+
+    if (heure_passee && !heure_arret_passee && sysvar.celsius[sysvar.dallas_maitre]< temperature ) {
+      commande_run();
       return true;
     }
-  return false; 
+    return false;
+  }
+
+  bool stop_progr() {
+    int heures;
+    int minutes;
+    /// sécurité temp
+    if ( sysvar.celsius[sysvar.dallas_maitre]>= temperature ) {
+      run=false;
+      security = true;
+      // protection flicking
+      sscanf(heure_demarrage, "%d:%d", &heures, &minutes);
+
+      if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min) {
+        delay(15000);
+      }
+      return true;
+    }
+
+    sscanf(heure_arret, "%d:%d", &heures, &minutes);
+
+
+
+    if(getLocalTime(&timeinfo)) {
+      if (heures == timeinfo.tm_hour && minutes == timeinfo.tm_min) {
+        run=false;
+        return true;
+      }
+    }
+    return false;
+  }
+  /// démarrage si le seuil est atteint
+  bool start_seuil() {
+    if ( unified_dimmer.get_power() >= seuil_start && sysvar.celsius[sysvar.dallas_maitre]< seuil_temperature &&
+         seuil_start != seuil_stop) {
+      return true;
+    }
+    return false;
   }
 
   /// arrêt si le seuil est atteint
   bool stop_seuil() {
-    if ( unified_dimmer.get_power() >= seuil_stop && seuil_start != seuil_stop && sysvar.celsius[sysvar.dallas_maitre]> seuil_temperature) { 
+    if ( unified_dimmer.get_power() >= seuil_stop && seuil_start != seuil_stop &&
+         sysvar.celsius[sysvar.dallas_maitre]> seuil_temperature) {
       return true;
     }
-  return false;
+    return false;
   }
 
   /// arret si seuil temp est atteint
   bool stop_seuil_temp() {
-    if ( sysvar.celsius[sysvar.dallas_maitre]>= seuil_temperature && seuil_temperature != 0) { 
+    if ( sysvar.celsius[sysvar.dallas_maitre]>= seuil_temperature && seuil_temperature != 0) {
       return true;
     }
-  return false;
+    return false;
   }
 
- /// vérification de la conformité de la donnée heure_demarrage[6]; 
- bool check_data(char data[6]){
-  int heures;
-  int minutes;
-  int result = sscanf(data, "%d:%d", &heures, &minutes);
-  if (result != 2) {
+  /// vérification de la conformité de la donnée heure_demarrage[6];
+  bool check_data(char data[6]){
+    int heures;
+    int minutes;
+    int result = sscanf(data, "%d:%d", &heures, &minutes);
+    if (result != 2) {
+      Serial.println("Erreur de lecture de l'heure");
+      return true;
+    }
+    if (heures >= 0 && heures <= 23 && minutes >= 0 && minutes <= 59) {
+      return false;
+    }
     Serial.println("Erreur de lecture de l'heure");
     return true;
   }
-  if (heures >= 0 && heures <= 23 && minutes >= 0 && minutes <= 59) {
-      return false;
-    }
-  Serial.println("Erreur de lecture de l'heure");
-  return true;
- }
 
 };
 

--- a/src/function/mqtt.h
+++ b/src/function/mqtt.h
@@ -3,7 +3,7 @@
 
 // Web services
 #include <ESPAsyncWebServer.h>
-#include <ArduinoJson.h> 
+#include <ArduinoJson.h>
 #include "config/config.h"
 #include "function/unified_dimmer.h"
 
@@ -14,11 +14,11 @@
 #else
 // Web services
   #include <ESP8266WiFi.h>
-  //#include <ESPAsyncTCP.h>
-  #include <ESP8266HTTPClient.h> 
+// #include <ESPAsyncTCP.h>
+  #include <ESP8266HTTPClient.h>
 #endif
 
-extern Config config; 
+extern Config config;
 extern System sysvar;
 extern HTTPClient http;
 extern WiFiClient domotic_client;
@@ -34,7 +34,7 @@ extern HA device_dimmer_maxtemp;
 extern HA device_dimmer_on_off;
 extern HA device_dimmer_alarm_temp;
 extern HA device_dimmer_power;
-extern HA device_dimmer_send_power; 
+extern HA device_dimmer_send_power;
 extern HA device_dimmer_total_power;
 extern HA device_temp[MAX_DALLAS];
 extern HA device_temp_master;
@@ -45,12 +45,12 @@ extern HA device_dimmer_alarm_temp_clear;
 
 
 extern bool HA_reconnected;
-extern bool discovery_temp; 
-extern bool alerte; 
-//extern byte security; // sécurité
-extern Logs logging; 
+extern bool discovery_temp;
+extern bool alerte;
+// extern byte security; // sécurité
+extern Logs logging;
 extern String devAddrNames[MAX_DALLAS];
-extern   PubSubClient client; 
+extern PubSubClient client;
 
 
 void connectToMqtt();
@@ -59,34 +59,34 @@ void onMqttSubscribe(uint16_t packetId, uint8_t qos);
 void recreate_topic();
 
 char buffer[1024];// NOSONAR
-  /// @brief Enregistrement du dimmer sur MQTT pour récuperer les informations remonté par MQTT
-  /// @param topic 
-  /// @param message 
-  /// @param length 
+/// @brief Enregistrement du dimmer sur MQTT pour récuperer les informations remonté par MQTT
+/// @param topic
+/// @param message
+/// @param length
 
 String stringBoolMQTT(bool mybool);
 
-  String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
-  String node_id = String("dimmer-") + node_mac; 
-  
-  String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
-  
-  String command_switch = String(topic_Xlyric + "command/switch");
-  String command_number = String(topic_Xlyric + "command/number");
-  String command_select = String(topic_Xlyric + "command/select");
-  String command_button = String(topic_Xlyric + "command/button");
-  const String HA_status = String("homeassistant/status");
-  String command_save = String("Xlyric/sauvegarde/"+ node_id );
+String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
+String node_id = String("dimmer-") + node_mac;
+
+String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
+
+String command_switch = String(topic_Xlyric + "command/switch");
+String command_number = String(topic_Xlyric + "command/number");
+String command_select = String(topic_Xlyric + "command/select");
+String command_button = String(topic_Xlyric + "command/button");
+const String HA_status = String("homeassistant/status");
+String command_save = String("Xlyric/sauvegarde/"+ node_id );
 
 void callback(char* topic, byte* payload, unsigned int length) {
-  //char arrivage[length+1]; // Ajout d'un espace pour le caractère nul // NOSONAR
-  //int recup = 0;
+  // char arrivage[length+1]; // Ajout d'un espace pour le caractère nul // NOSONAR
+  // int recup = 0;
   char* arrivage = new char[length + 1];
-  
-    for (unsigned int i=0;i<length;i++) {
-      arrivage[i] = (char)payload[i];
-    }
-   arrivage[length] = '\0'; // Ajouter le caractère nul à la fin
+
+  for (unsigned int i=0; i<length; i++) {
+    arrivage[i] = (char)payload[i];
+  }
+  arrivage[length] = '\0';  // Ajouter le caractère nul à la fin
 
   // debug
   Serial.println("length : " + String(length));
@@ -96,24 +96,23 @@ void callback(char* topic, byte* payload, unsigned int length) {
   JsonDocument doc2;
   deserializeJson(doc2, arrivage);
   /// @brief Enregistrement du dimmer sur MQTT pour récuperer les informations remontées par MQTT
-  if (strcmp( topic, config.SubscribePV ) == 0 && doc2.containsKey("power")) { 
-    int puissancemqtt = doc2["power"]; 
+  if (strcmp( topic, config.SubscribePV ) == 0 && doc2.containsKey("power")) {
+    int puissancemqtt = doc2["power"];
     puissancemqtt = puissancemqtt - config.startingpow;
     if (puissancemqtt < 0) puissancemqtt = 0;
     if (sysvar.puissance != puissancemqtt ) {
       sysvar.puissance = puissancemqtt;
-      sysvar.change=1; 
-    }
-    else if (config.dimmer_on_off == 1){
+      sysvar.change=1;
+    } else if (config.dimmer_on_off == 1) {
       device_dimmer.send(String(sysvar.puissance));
       device_dimmer_send_power.send(String(sysvar.puissance));
       device_dimmer_power.send(String(sysvar.puissance*config.charge/100));
     }
   }
   /// @brief Enregistrement temperature
-  if (strcmp( topic, config.SubscribeTEMP ) == 0 && doc2.containsKey("temperature")){ 
+  if (strcmp( topic, config.SubscribeTEMP ) == 0 && doc2.containsKey("temperature")) {
     Serial.println("lecture temperature MQTT ");
-    float temperaturemqtt = doc2["temperature"]; 
+    float temperaturemqtt = doc2["temperature"];
     Serial.println(temperaturemqtt);
     sysvar.dallas_maitre= deviceCount+1;
     devAddrNames[deviceCount+1] = "MQTT";
@@ -138,137 +137,130 @@ void callback(char* topic, byte* payload, unsigned int length) {
     }
   }
 
-  /// @brief Enregistrement des requetes de commandes 
-  if (strstr( topic, command_switch.c_str() ) != NULL) { 
+  /// @brief Enregistrement des requetes de commandes
+  if (strstr( topic, command_switch.c_str() ) != NULL) {
     #ifdef RELAY1
-      if (doc2.containsKey("relay1")) { 
-          int relay = doc2["relay1"]; 
-          if ( relay == 0) { digitalWrite(RELAY1 , LOW); }
-          else { digitalWrite(RELAY1 , HIGH); } 
-          logging.Set_log_init("RELAY1 at ");
-          logging.Set_log_init(String(relay).c_str());
-          logging.Set_log_init("\r\n"); 
-          device_relay1.send(String(relay));
-      }
+    if (doc2.containsKey("relay1")) {
+      int relay = doc2["relay1"];
+      if ( relay == 0) { digitalWrite(RELAY1, LOW); }
+      else { digitalWrite(RELAY1, HIGH); }
+      logging.Set_log_init("RELAY1 at ");
+      logging.Set_log_init(String(relay).c_str());
+      logging.Set_log_init("\r\n");
+      device_relay1.send(String(relay));
+    }
     #endif
     #ifdef RELAY2
-      if (doc2.containsKey("relay2")) { 
-          int relay = doc2["relay2"]; 
-          if ( relay == 0) { digitalWrite(RELAY2 , LOW); }
-          else { digitalWrite(RELAY2 , HIGH); } 
-          logging.Set_log_init("RELAY2 at ");
-          logging.Set_log_init(String(relay).c_str());
-          logging.Set_log_init("\r\n"); 
-          device_relay2.send(String(relay));      
-      }
-    #endif
-    if (doc2.containsKey("on_off")) { 
-        int relay = doc2["on_off"]; 
-        if ( relay == 0) { config.dimmer_on_off = false; }
-          else { config.dimmer_on_off = true; }
-        logging.Set_log_init("Dimmer ON_OFF at ");
-        logging.Set_log_init(String(config.dimmer_on_off).c_str());
-        logging.Set_log_init("\r\n"); 
-        device_dimmer_on_off.send(String(config.dimmer_on_off));      
-        sysvar.change=1; 
-        
+    if (doc2.containsKey("relay2")) {
+      int relay = doc2["relay2"];
+      if ( relay == 0) { digitalWrite(RELAY2, LOW); }
+      else { digitalWrite(RELAY2, HIGH); }
+      logging.Set_log_init("RELAY2 at ");
+      logging.Set_log_init(String(relay).c_str());
+      logging.Set_log_init("\r\n");
+      device_relay2.send(String(relay));
     }
-    
-  } 
+    #endif
+    if (doc2.containsKey("on_off")) {
+      int relay = doc2["on_off"];
+      if ( relay == 0) { config.dimmer_on_off = false; }
+      else { config.dimmer_on_off = true; }
+      logging.Set_log_init("Dimmer ON_OFF at ");
+      logging.Set_log_init(String(config.dimmer_on_off).c_str());
+      logging.Set_log_init("\r\n");
+      device_dimmer_on_off.send(String(config.dimmer_on_off));
+      sysvar.change=1;
+    }
+  }
 
-  if (strstr( topic, command_number.c_str() ) != NULL) { 
-    if (doc2.containsKey("starting_power")) { 
-      int startingpow = doc2["starting_power"]; 
+  if (strstr( topic, command_number.c_str() ) != NULL) {
+    if (doc2.containsKey("starting_power")) {
+      int startingpow = doc2["starting_power"];
       if (config.startingpow != startingpow ) {
         config.startingpow = startingpow;
         logging.Set_log_init("MQTT starting_pow at ");
         logging.Set_log_init(String(startingpow).c_str());
         logging.Set_log_init("%\r\n");
         device_dimmer_starting_pow.send(String(startingpow));
-        sysvar.change=1; 
+        sysvar.change=1;
       }
     }
-    else if (doc2.containsKey("minpow")) { 
-      int minpow = doc2["minpow"]; 
+    else if (doc2.containsKey("minpow")) {
+      int minpow = doc2["minpow"];
       if (config.minpow != minpow ) {
         config.minpow = minpow;
         logging.Set_log_init("MQTT minpow at " );
-        logging.Set_log_init(String(minpow).c_str()); 
+        logging.Set_log_init(String(minpow).c_str());
         logging.Set_log_init("%\r\n");
         device_dimmer_minpow.send(String(minpow));
-        sysvar.change=1; 
+        sysvar.change=1;
       }
     }
-    else if (doc2.containsKey("maxpow")) { 
-      int maxpow = doc2["maxpow"]; 
+    else if (doc2.containsKey("maxpow")) {
+      int maxpow = doc2["maxpow"];
       if (config.maxpow != maxpow ) {
         config.maxpow = maxpow;
         logging.Set_log_init("MQTT maxpow at ");
         logging.Set_log_init(String(maxpow).c_str());
         logging.Set_log_init("%\r\n");
         device_dimmer_maxpow.send(String(maxpow));
-        sysvar.change=1; 
+        sysvar.change=1;
       }
     }
-    else if (doc2.containsKey("powdimmer")) { 
-      int powdimmer = doc2["powdimmer"]; 
+    else if (doc2.containsKey("powdimmer")) {
+      int powdimmer = doc2["powdimmer"];
       if (sysvar.puissance != powdimmer ) {
-        if ( config.maxpow != 0 && powdimmer > config.maxpow ) { powdimmer = config.maxpow; } 
+        if ( config.maxpow != 0 && powdimmer > config.maxpow ) { powdimmer = config.maxpow; }
         sysvar.puissance = powdimmer;
-        sysvar.change=1; 
+        sysvar.change=1;
         logging.Set_log_init("MQTT power at ");
         logging.Set_log_init(String(powdimmer).c_str());
         logging.Set_log_init("%\r\n");
-       
       }
     }
-    else if (doc2.containsKey("maxtemp")) { 
-      int maxtemp = doc2["maxtemp"]; 
+    else if (doc2.containsKey("maxtemp")) {
+      int maxtemp = doc2["maxtemp"];
       if (config.maxtemp != maxtemp ) {
         config.maxtemp = maxtemp;
-        logging.Set_log_init("MQTT maxtemp at ");  
+        logging.Set_log_init("MQTT maxtemp at ");
         logging.Set_log_init(String(maxtemp).c_str());
         logging.Set_log_init("°C\r\n");
         device_dimmer_maxtemp.send(String(maxtemp));
-        sysvar.change=1; 
+        sysvar.change=1;
       }
     }
-    else if (doc2.containsKey("charge")) { 
-      int charge = doc2["charge"]; 
+    else if (doc2.containsKey("charge")) {
+      int charge = doc2["charge"];
       if (config.charge != charge ) {
         config.charge = charge;
         logging.Set_log_init("MQTT charge at ");
         logging.Set_log_init(String(charge).c_str());
         logging.Set_log_init("W\r\n");
-        sysvar.change=1; 
+        sysvar.change=1;
       }
     }
   }
-//clear alarm & save
-  if (strstr( topic, command_button.c_str() ) != NULL) { 
-    if (doc2.containsKey("reset_alarm")) { 
+  // clear alarm & save
+  if (strstr( topic, command_button.c_str() ) != NULL) {
+    if (doc2.containsKey("reset_alarm")) {
       if (doc2["reset_alarm"] == "1" ) {
         logging.Set_log_init(Clear_alarm_temp,true);
-        sysvar.security = 0 ;
-        device_dimmer_alarm_temp.send(stringBoolMQTT(sysvar.security)); 
-        sysvar.change = 1 ;
+        sysvar.security = 0;
+        device_dimmer_alarm_temp.send(stringBoolMQTT(sysvar.security));
+        sysvar.change = 1;
       }
     }
-    else if (doc2.containsKey("save")) { 
+    else if (doc2.containsKey("save")) {
       if (doc2["save"] == "1" ) {
-        logging.Set_log_init(config.saveConfiguration()); //sauvegarde de la configuration
-          
+        logging.Set_log_init(config.saveConfiguration()); // sauvegarde de la configuration
       }
     }
-
-
   }
 
-
-//child mode
-  if (strstr( topic, command_select.c_str() ) != NULL) { 
-    if (doc2.containsKey("child_mode")) { 
-      String childmode = doc2["child_mode"]; 
+  // child mode
+  if (strstr( topic, command_select.c_str() ) != NULL) {
+    if (doc2.containsKey("child_mode")) {
+      String childmode = doc2["child_mode"];
       if (config.mode != doc2["child_mode"] ) {
         strlcpy(config.mode, doc2["child_mode"], sizeof(config.mode));
         device_dimmer_child_mode.send(String(config.mode));
@@ -279,201 +271,206 @@ void callback(char* topic, byte* payload, unsigned int length) {
       }
     }
   }
-  if (strcmp( topic, command_save.c_str() ) == 0) { 
-        strlcpy(config.hostname , doc2["hostname"], sizeof(config.hostname));
-        config.port = doc2["port"];
-        strlcpy(config.Publish , doc2["Publish"], sizeof(config.Publish));
-        config.IDXTemp = doc2["IDXTemp"];
-        config.maxtemp = doc2["maxtemp"];
-        config.IDXAlarme = doc2["IDXAlarme"];
-        config.IDX = doc2["IDX"];  
-        config.startingpow = doc2["startingpow"];
-        config.minpow = doc2["minpow"];
-        config.maxpow = doc2["maxpow"];
-        strlcpy(config.child , doc2["child"], sizeof(config.child)) ;
-        strlcpy(config.mode , doc2["mode"], sizeof(config.mode)) ;
-        strlcpy(config.SubscribePV , doc2["SubscribePV"], sizeof(config.SubscribePV));
-        strlcpy(config.SubscribeTEMP , doc2["SubscribeTEMP"], sizeof(config.SubscribeTEMP));
-        Serial.println("sauvegarde conf mqtt ");
-        serializeJson(doc2, buffer);
-        Serial.println(config.hostname);
-        Serial.println(buffer);
+  if (strcmp( topic, command_save.c_str() ) == 0) {
+    strlcpy(config.hostname, doc2["hostname"], sizeof(config.hostname));
+    config.port = doc2["port"];
+    strlcpy(config.Publish, doc2["Publish"], sizeof(config.Publish));
+    config.IDXTemp = doc2["IDXTemp"];
+    config.maxtemp = doc2["maxtemp"];
+    config.IDXAlarme = doc2["IDXAlarme"];
+    config.IDX = doc2["IDX"];
+    config.startingpow = doc2["startingpow"];
+    config.minpow = doc2["minpow"];
+    config.maxpow = doc2["maxpow"];
+    strlcpy(config.child, doc2["child"], sizeof(config.child));
+    strlcpy(config.mode, doc2["mode"], sizeof(config.mode));
+    strlcpy(config.SubscribePV, doc2["SubscribePV"], sizeof(config.SubscribePV));
+    strlcpy(config.SubscribeTEMP, doc2["SubscribeTEMP"], sizeof(config.SubscribeTEMP));
+    Serial.println("sauvegarde conf mqtt ");
+    serializeJson(doc2, buffer);
+    Serial.println(config.hostname);
+    Serial.println(buffer);
   }
 
+  if (strcmp( topic, HA_status.c_str() ) == 0) {
+    logging.Set_log_init("MQTT HA_status ",true);
+    logging.Set_log_init(fixedpayload);
+    logging.Set_log_init("\r\n");
+    if (strcmp( fixedpayload.c_str(), "online" ) == 0) {
+      logging.Set_log_init("MQTT resend HA discovery \r\n",true);
+      HA_discover();
+      logging.Set_log_init("MQTT resend all values \r\n",true);
+      device_dimmer.send(String(sysvar.puissance));
+      device_dimmer_send_power.send(String(sysvar.puissance));
+      device_dimmer_power.send(String(sysvar.puissance* config.charge/100));
+      if (
+        strcmp(String(config.PVROUTER).c_str(), "http") == 0
+        ) {
+        device_dimmer_total_power.send(
+          String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100))
+          );
+      }
+      device_cooler.send(stringBoolMQTT(sysvar.cooler));
+      device_temp_master.send(String(sysvar.celsius[sysvar.dallas_maitre]));
+      device_dimmer_starting_pow.send(String(config.startingpow));
+      device_dimmer_minpow.send(String(config.minpow));
+      device_dimmer_maxpow.send(String(config.maxpow));
+      device_dimmer_maxtemp.send(String(config.maxtemp));
+      if (strcmp(String(config.PVROUTER).c_str(), "http") == 0) {
+        device_dimmer_child_mode.send(String(config.mode));
+      }
+      device_dimmer_on_off.send(String(config.dimmer_on_off));
 
-  if (strcmp( topic, HA_status.c_str() ) == 0) { 
-        logging.Set_log_init("MQTT HA_status ",true);
-        logging.Set_log_init(fixedpayload);
-        logging.Set_log_init("\r\n");
-        if (strcmp( fixedpayload.c_str(), "online" ) == 0) { 
-          logging.Set_log_init("MQTT resend HA discovery \r\n",true);
-          HA_discover();
-          logging.Set_log_init("MQTT resend all values \r\n",true);
-          device_dimmer.send(String(sysvar.puissance));
-          device_dimmer_send_power.send(String(sysvar.puissance));
-          device_dimmer_power.send(String(sysvar.puissance* config.charge/100));
-          if (strcmp(String(config.PVROUTER).c_str() , "http") == 0) { device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));}
-          device_cooler.send(stringBoolMQTT(sysvar.cooler));
-          device_temp_master.send(String(sysvar.celsius[sysvar.dallas_maitre]));
-          device_dimmer_starting_pow.send(String(config.startingpow));
-          device_dimmer_minpow.send(String(config.minpow));
-          device_dimmer_maxpow.send(String(config.maxpow));
-          device_dimmer_maxtemp.send(String(config.maxtemp));
-          if (strcmp(String(config.PVROUTER).c_str() , "http") == 0) {device_dimmer_child_mode.send(String(config.mode));}
-          device_dimmer_on_off.send(String(config.dimmer_on_off));
-
-          #ifdef RELAY1
-            int relaystate = digitalRead(RELAY1); 
-            device_relay1.send(String(relaystate));
-          #endif
-          #ifdef RELAY2
-            relaystate = digitalRead(RELAY2); 
-            device_relay2.send(String(relaystate));
-          #endif
-          if (discovery_temp) {
-            for (int i = 0; i < deviceCount; i++) {  //NOSONAR
-              device_temp[i].send(String(sysvar.celsius[i]));
-            }
-            device_temp_master.send(String(sysvar.celsius[sysvar.dallas_maitre]));
-            Serial.println(sysvar.celsius[sysvar.dallas_maitre]);
-            device_dimmer_alarm_temp.send(stringBoolMQTT(sysvar.security));
-            device_dimmer_maxtemp.send(String(config.maxtemp)); 
-          }
+      #ifdef RELAY1
+      int relaystate = digitalRead(RELAY1);
+      device_relay1.send(String(relaystate));
+      #endif
+      #ifdef RELAY2
+      relaystate = digitalRead(RELAY2);
+      device_relay2.send(String(relaystate));
+      #endif
+      if (discovery_temp) {
+        for (int i = 0; i < deviceCount; i++) {      //NOSONAR
+          device_temp[i].send(String(sysvar.celsius[i]));
         }
+        device_temp_master.send(String(sysvar.celsius[sysvar.dallas_maitre]));
+        Serial.println(sysvar.celsius[sysvar.dallas_maitre]);
+        device_dimmer_alarm_temp.send(stringBoolMQTT(sysvar.security));
+        device_dimmer_maxtemp.send(String(config.maxtemp));
+      }
+    }
   }
   delete[] arrivage;
 }
 
-void Mqtt_send_DOMOTICZ(String idx, String value, String name="")
-{
-
+void Mqtt_send_DOMOTICZ(String idx, String value, String name="") {
   if (config.DOMOTICZ) {
-      String nvalue = "0" ; 
-      String retour; 
-      JsonDocument doc;
-      if ( value != "0" ) { nvalue = "2" ; }
-      doc["idx"] = idx.toInt();
-      doc["nvalue"] = nvalue.toInt();
-      doc["svalue"] = value;
-      doc["name"] = name;
-      serializeJson(doc, retour);
-      // si config.Publish est vide, on ne publie pas
-      if (strlen(config.Publish) != 0 ) {
-        client.publish(config.Publish, retour.c_str(), true);
-      }
+    String nvalue = "0";
+    String retour;
+    JsonDocument doc;
+    if ( value != "0" ) { nvalue = "2"; }
+    doc["idx"] = idx.toInt();
+    doc["nvalue"] = nvalue.toInt();
+    doc["svalue"] = value;
+    doc["name"] = name;
+    serializeJson(doc, retour);
+    // si config.Publish est vide, on ne publie pas
+    if (strlen(config.Publish) != 0 ) {
+      client.publish(config.Publish, retour.c_str(), true);
     }
+  }
 
-    if (config.JEEDOM) {
-      String jeedom_publish = String(config.Publish) + "/" + idx ; 
-      // si config.Publish est vide, on ne publie pas
-      if (strlen(config.Publish) != 0 ) {
-        client.publish(jeedom_publish.c_str(), value.c_str(), true);
-      }
+  if (config.JEEDOM) {
+    String jeedom_publish = String(config.Publish) + "/" + idx;
+    // si config.Publish est vide, on ne publie pas
+    if (strlen(config.Publish) != 0 ) {
+      client.publish(jeedom_publish.c_str(), value.c_str(), true);
     }
-
-    Serial.println("MQTT SENT");
-
+  }
+  Serial.println("MQTT SENT");
 }
 
 
 //// communication avec carte fille ( HTTP )
-
 void child_communication(int delest_power, bool equal = false){
+  int tmp_puissance_dispo=0;
+  String baseurl;
+  baseurl = "/?POWER=" + String(delest_power);
 
-    int tmp_puissance_dispo=0 ;
-  String baseurl; 
-    baseurl = "/?POWER=" + String(delest_power); 
-  
   /// Modif RV 20240219
   /// Ajout de " delest_power != 0" pour ne pas envoyer une demande de puissance si on le passe de toutes façons à 0
-  if (sysvar.puissance_dispo !=0 && delest_power != 0) {  
+  if (sysvar.puissance_dispo !=0 && delest_power != 0) {
     baseurl.concat("&puissance=");
-    if ( strcmp(config.child,"") != 0 && strcmp(config.mode,"equal") == 0 ) { tmp_puissance_dispo = sysvar.puissance_dispo/2;}
-    else { tmp_puissance_dispo = sysvar.puissance_dispo; }
-      baseurl.concat(String(tmp_puissance_dispo)); 
+    if (
+      strcmp(config.child, "") != 0
+      && strcmp(config.mode,"equal") == 0
+      ) {
+      tmp_puissance_dispo = sysvar.puissance_dispo/2;
+    } else {
+      tmp_puissance_dispo = sysvar.puissance_dispo;
+    }
+    baseurl.concat(String(tmp_puissance_dispo));
   }
-  
-  http.begin(domotic_client,config.child,80,baseurl); 
-  http.GET();
-  http.end(); 
 
+  http.begin(domotic_client,config.child,80,baseurl);
+  http.GET();
+  http.end();
 }
 
 
 //////////// reconnexion MQTT
 
 void connect_and_subscribe() {
-  if  (LittleFS.exists("/mqtt.json"))
-  {
-      if (!client.connected() && WiFi.isConnected()) {
-        Serial.print("Attempting MQTT connection...\n");
-        connectToMqtt();
-        delay(1000); // Attente d'avoir le callback de connexion MQTT avant de faire les subscriptions
-      }
-      
-      
-      if (mqttConnected) {
-        recreate_topic();
-        logging.Set_log_init(Subscribe_MQTT);
+  if  (LittleFS.exists("/mqtt.json")) {
+    if (!client.connected() && WiFi.isConnected()) {
+      Serial.print("Attempting MQTT connection...\n");
+      connectToMqtt();
+      delay(1000);   // Attente d'avoir le callback de connexion MQTT avant de faire les subscriptions
+    }
 
-        Serial.println("connected");
-        logging.Set_log_init("Connected\r\n");
+    if (mqttConnected) {
+      recreate_topic();
+      logging.Set_log_init(Subscribe_MQTT);
 
-        logging.Set_log_init("Call HA discover\r\n");
-        Serial.println("Call HA discover");
-        HA_discover();
+      Serial.println("connected");
+      logging.Set_log_init("Connected\r\n");
 
-        logging.Set_log_init("Other subscriptions...\r\n");
-        Serial.println("Other subscriptions...");
-        if (mqtt_config.mqtt && strlen(config.SubscribePV) !=0 ) {client.subscribe(config.SubscribePV,1);}
-        if (mqtt_config.mqtt && strlen(config.SubscribeTEMP) != 0 ) {client.subscribe(config.SubscribeTEMP,1);}
-        client.subscribe(command_switch.c_str(),1);
-        client.subscribe(command_number.c_str(),1);
-        client.subscribe(command_select.c_str(),1);
-        client.subscribe(command_button.c_str(),1);
+      logging.Set_log_init("Call HA discover\r\n");
+      Serial.println("Call HA discover");
+      HA_discover();
 
-        String node_id = config.say_my_name;
-        String save_command = String("Xlyric/sauvegarde/"+ node_id );
+      logging.Set_log_init("Other subscriptions...\r\n");
+      Serial.println("Other subscriptions...");
+      if (mqtt_config.mqtt && strlen(config.SubscribePV) !=0 ) {client.subscribe(config.SubscribePV,1);}
+      if (mqtt_config.mqtt && strlen(config.SubscribeTEMP) != 0 ) {client.subscribe(config.SubscribeTEMP,1);}
+      client.subscribe(command_switch.c_str(),1);
+      client.subscribe(command_number.c_str(),1);
+      client.subscribe(command_select.c_str(),1);
+      client.subscribe(command_button.c_str(),1);
 
-        int instant_power = sysvar.puissance;  // 
-        Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100));   /// correction 19/04 valeur remonté au dessus du max conf
-        device_dimmer.send(String(instant_power)); 
-        device_dimmer_power.send(String(instant_power * config.charge/100)); 
-      }
+      String node_id = config.say_my_name;
+      String save_command = String("Xlyric/sauvegarde/"+ node_id );
+
+      int instant_power = sysvar.puissance;
+      /// correction 19/04 valeur remonté au dessus du max conf
+      Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100));
+      device_dimmer.send(String(instant_power));
+      device_dimmer_power.send(String(instant_power * config.charge/100));
+    }
   } else {  Serial.println(" Filesystem not present "); delay(5000); }
 }
-//#define MQTT_HOST IPAddress(192, 168, 1, 20)
+// #define MQTT_HOST IPAddress(192, 168, 1, 20)
 char arrayWill[64];// NOSONAR
 void async_mqtt_init() {
   String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
-  String topic_Xlyric = "Xlyric/dimmer-" + node_mac +"/";; 
-  //String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
-	const String LASTWILL_TOPIC = topic_Xlyric + "status";
-	LASTWILL_TOPIC.toCharArray(arrayWill, 64);
+  String topic_Xlyric = "Xlyric/dimmer-" + node_mac +"/";;
+  // String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
+  const String LASTWILL_TOPIC = topic_Xlyric + "status";
+  LASTWILL_TOPIC.toCharArray(arrayWill, 64);
   IPAddress ip;
   ip.fromString(config.hostname);
   DEBUG_PRINTLN(ip);
-  //client.setClientId(node_id.c_str());
-  
-  //client.setWill(arrayWill, 2, true, "offline");
- // client.setCredentials(mqtt_config.username, mqtt_config.password);
-  //client.onDisconnect(onMqttDisconnect);
-  //client.onSubscribe(onMqttSubscribe);
-  //client.onMessage(callback);
+  // client.setClientId(node_id.c_str());
 
-  //client.setServer(ip, config.port);
- // client.setMaxTopicLength(768); // 1024 -> 768 
- // 
+  // client.setWill(arrayWill, 2, true, "offline");
+  // client.setCredentials(mqtt_config.username, mqtt_config.password);
+  // client.onDisconnect(onMqttDisconnect);
+  // client.onSubscribe(onMqttSubscribe);
+  // client.onMessage(callback);
+
+  // client.setServer(ip, config.port);
+  // client.setMaxTopicLength(768); // 1024 -> 768
+  //
 
   client.setServer(ip, config.port);
   client.setCallback(callback);
   connectToMqtt();
-  
-  }
+
+}
 
 void connectToMqtt() {
   if (!client.connected() ) {
-  DEBUG_PRINTLN(Connecting_MQTT);
+    DEBUG_PRINTLN(Connecting_MQTT);
     logging.Set_log_init(String(Connecting_MQTT) + String(config.say_my_name) + " \r\n");
     delay(500); // pour laisser le temps de se connecter au wifi ou ne pas spam le serveur
     Serial.println(config.hostname);
@@ -484,7 +481,7 @@ void connectToMqtt() {
     client.setKeepAlive(120);
     client.setBufferSize(1024);
     client.connect(config.say_my_name, mqtt_config.username, mqtt_config.password, arrayWill, 2, true, "offline");
-    
+
   }
   // affig en debug k'état de client.connected
   if (client.connected()) {
@@ -495,7 +492,7 @@ void connectToMqtt() {
     HA_discover();
     onMqttConnect(true);
     client.setCallback(callback);
-  } 
+  }
 }
 
 void onMqttConnect(bool sessionPresent) {
@@ -503,20 +500,21 @@ void onMqttConnect(bool sessionPresent) {
   logging.Set_log_init("Connected to MQTT.\r\n");
   Serial.print("Session present: ");
   Serial.println(sessionPresent);
-  //String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
+  // String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
   String node_mac = WiFi.macAddress().substring(12,14)+ WiFi.macAddress().substring(15,17);
-  String topic_Xlyric = "Xlyric/dimmer-" + node_mac +"/";; 
+  String topic_Xlyric = "Xlyric/dimmer-" + node_mac +"/";;
 
-  client.publish(String(topic_Xlyric +"status").c_str(),"online",true);         // Once connected, publish online to the availability topic
-  
+  // Once connected, publish online to the availability topic
+  client.publish(String(topic_Xlyric +"status").c_str(),"online",true);
+
   if (strlen(config.SubscribePV) !=0 ) {
     client.subscribe(config.SubscribePV,1);
     Serial.println(config.SubscribePV);
-    }
+  }
   if (strlen(config.SubscribeTEMP) != 0 ) {
     client.subscribe(config.SubscribeTEMP,1);
     Serial.println(config.SubscribeTEMP);
-    }
+  }
   client.subscribe((command_button + "/#").c_str(),1);
   client.subscribe((command_number + "/#").c_str(),1);
   client.subscribe((command_select + "/#").c_str(),1);
@@ -530,7 +528,6 @@ void onMqttConnect(bool sessionPresent) {
   mqttConnected = true;
 }
 
-
 void onMqttSubscribe(uint16_t packetId, uint8_t qos) {
   Serial.println("Subscribe acknowledged.");
   Serial.print("  packetId: ");
@@ -543,6 +540,7 @@ String stringBoolMQTT(bool mybool){
   if (mybool == false ) {truefalse = "false";}
   return String(truefalse);
 }
+
 void recreate_topic(){
   String topic_Xlyric = "Xlyric/" + String(config.say_my_name) +"/";
   Serial.println("test "+String(config.say_my_name));

--- a/src/function/unified_dimmer.h
+++ b/src/function/unified_dimmer.h
@@ -1,49 +1,49 @@
 #ifndef UNIFIED_DIMMER_FUNCTIONS
 #define UNIFIED_DIMMER_FUNCTIONS
 
-// le but de cette fonction est de centraliser les commandes de dimmer  ( robotdyn et SSR ) de façon uniforme 
+// le but de cette fonction est de centraliser les commandes de dimmer  ( robotdyn et SSR ) de façon uniforme
 
 #include <Arduino.h>
 #ifdef ROBOTDYN
   #include "function/dimmer.h"
-  extern dimmerLamp dimmer;
-  extern dimmerLamp dimmer2;
-  extern dimmerLamp dimmer3;
+extern dimmerLamp dimmer;
+extern dimmerLamp dimmer2;
+extern dimmerLamp dimmer3;
 #else
-    #include "function/jotta.h"
+  #include "function/jotta.h"
 #endif
 
 
 // @brief  structure pour uniformiser les commandes de puissances entre robotdyn et SSR
-struct gestion_puissance
-{
-public:float power;
+struct gestion_puissance {
+public: float power;
 
-// setter
-void set_power(float is_set_power){
-  if ( sysvar.celsius[sysvar.dallas_maitre]> config.maxtemp ) { is_set_power = 0; } /// si la température est supérieur à la température max on coupe tout
-  else if ( is_set_power > config.maxpow )  { is_set_power = config.maxpow; }
+  // setter
+  void set_power(float is_set_power){
+    /// si la température est supérieur à la température max on coupe tout
+    if ( sysvar.celsius[sysvar.dallas_maitre]> config.maxtemp ) { is_set_power = 0; }
+    else if ( is_set_power > config.maxpow )  { is_set_power = config.maxpow; }
 
-  /// vérification de la température 
-  
-  this->power = is_set_power;
-  /// pour le SSR
+    /// vérification de la température
+
+    this->power = is_set_power;
+    /// pour le SSR
   #ifdef SSR_ZC
     ssr_burst.set_power(int(is_set_power));
   #endif
- 
+
   #ifdef SSR_RANDOM
     jotta_command(int(is_set_power));
   #endif
 
-  /// pour le dimmer robotdyn
+    /// pour le dimmer robotdyn
   #ifdef ROBOTDYN
     // On transforme la puissance totale à envoyer aux dimmers en watts pour mieux les répartir entre les 3 SSR
-    // Meilleure précision en float 
+    // Meilleure précision en float
     config.calcul_charge();
-    /// eviter les divisions par 0 
+    /// eviter les divisions par 0
     float tmp_pwr_watt = 0;
-    if ( int(is_set_power) >= 0 ) { tmp_pwr_watt = is_set_power * config.charge / 100; } 
+    if ( int(is_set_power) >= 0 ) { tmp_pwr_watt = is_set_power * config.charge / 100; }
 
 
     int dimmer1_pwr = 0;
@@ -51,116 +51,118 @@ void set_power(float is_set_power){
     int dimmer3_pwr = 0;
 
     // Calcul de la puissance à envoyer à chaque dimmer
-    if (tmp_pwr_watt <= config.charge1){ // Un seul dimmer à fournir
-      if ( tmp_pwr_watt > 0 ) { dimmer1_pwr = tmp_pwr_watt * 100 / config.charge1 ; } 
-      else 
-      { dimmer1_pwr = 0; }        
+    if (tmp_pwr_watt <= config.charge1) { // Un seul dimmer à fournir
+      if ( tmp_pwr_watt > 0 ) { dimmer1_pwr = tmp_pwr_watt * 100 / config.charge1; }
+      else { dimmer1_pwr = 0; }
       dimmer2_pwr = 0;
       dimmer3_pwr = 0;
     }
 
-    else if (tmp_pwr_watt <= (config.charge1+config.charge2)){ // 2 dimmers à fournir
-      if (config.charge1 != 0) { dimmer1_pwr = 100; } // Permet d'avoir le dimmer1 configuré à 0 dans l'interface web
-      if (config.charge2 != 0) { dimmer2_pwr = (tmp_pwr_watt - config.charge1 ) * 100 / config.charge2 ;} // Permet d'avoir le dimmer2 configuré à 0 dans l'interface web
+    else if (tmp_pwr_watt <= (config.charge1+config.charge2)) { // 2 dimmers à fournir
+      // Permet d'avoir le dimmer1 configuré à 0 dans l'interface web
+      if (config.charge1 != 0) { dimmer1_pwr = 100; }
+      // Permet d'avoir le dimmer2 configuré à 0 dans l'interface web
+      if (config.charge2 != 0) { dimmer2_pwr = (tmp_pwr_watt - config.charge1 ) * 100 / config.charge2;}
       dimmer3_pwr = 0;
     }
     else { // Les 3 dimmers à fournir
       if (config.charge1 != 0) { dimmer1_pwr = 100; } // Permet d'avoir le dimmer1 configuré à 0 dans l'interface web
       if (config.charge2 != 0) { dimmer2_pwr = 100; } // Permet d'avoir le dimmer2 configuré à 0 dans l'interface web
-      if (config.charge3 != 0) { dimmer3_pwr = (tmp_pwr_watt - (config.charge1 + config.charge2) ) * 100 / config.charge3; } else { dimmer3_pwr = 0;}
+      if (config.charge3 !=
+          0) { dimmer3_pwr = (tmp_pwr_watt - (config.charge1 + config.charge2) ) * 100 / config.charge3;
+      } else { dimmer3_pwr = 0;}
     }
-    
+
     Serial.println("power1" + String(dimmer1_pwr));
     // Application de la puissance à chaque dimmer
     // Dimmer1
     if ( dimmer1_pwr != dimmer.getPower() ) {
-     if (dimmer1_pwr == 0 && dimmer.getState()==1) {
-      dimmer.setPower(0);
-      dimmer.setState(OFF);
-      logging.Set_log_init("Dimmer1 Off\r\n");
-      delay(50);
-     }
-     else if (dimmer1_pwr != 0 && dimmer.getState()==0) {
-      dimmer.setState(ON);
-      logging.Set_log_init("Dimmer1 On\r\n");
-      delay(50);
-      dimmer.setPower(dimmer1_pwr);
-     }
-     else { dimmer.setPower(dimmer1_pwr); }
+      if (dimmer1_pwr == 0 && dimmer.getState()==1) {
+        dimmer.setPower(0);
+        dimmer.setState(OFF);
+        logging.Set_log_init("Dimmer1 Off\r\n");
+        delay(50);
+      }
+      else if (dimmer1_pwr != 0 && dimmer.getState()==0) {
+        dimmer.setState(ON);
+        logging.Set_log_init("Dimmer1 On\r\n");
+        delay(50);
+        dimmer.setPower(dimmer1_pwr);
+      }
+      else { dimmer.setPower(dimmer1_pwr); }
     }
-#ifdef outputPin2
+    #ifdef outputPin2
     // Dimmer2
     if ( dimmer2_pwr != dimmer2.getPower() ) {
-     if (dimmer2_pwr == 0 && dimmer2.getState()==1) {
-      dimmer2.setPower(0);
-      dimmer2.setState(OFF);
-      logging.Set_log_init("Dimmer2 Off\r\n");
-      delay(50);
-     }     
-     else if (dimmer2_pwr != 0 && dimmer2.getState()==0) {
-      dimmer2.setState(ON);
-      logging.Set_log_init("Dimmer2 On\r\n");
-      delay(50);
-      dimmer2.setPower(dimmer2_pwr);
-     }
-     else { dimmer2.setPower(dimmer2_pwr); }
+      if (dimmer2_pwr == 0 && dimmer2.getState()==1) {
+        dimmer2.setPower(0);
+        dimmer2.setState(OFF);
+        logging.Set_log_init("Dimmer2 Off\r\n");
+        delay(50);
+      }
+      else if (dimmer2_pwr != 0 && dimmer2.getState()==0) {
+        dimmer2.setState(ON);
+        logging.Set_log_init("Dimmer2 On\r\n");
+        delay(50);
+        dimmer2.setPower(dimmer2_pwr);
+      }
+      else { dimmer2.setPower(dimmer2_pwr); }
     }
-    
+
     // Dimmer3
-    if ( dimmer3_pwr != dimmer3.getPower() ) {  
-     if (dimmer3_pwr == 0 && dimmer3.getState()==1) {
-      dimmer3.setPower(0);
-      dimmer3.setState(OFF);
-      logging.Set_log_init("Dimmer3 Off\r\n");
-      delay(50);
-     }     
-     else if (dimmer3_pwr != 0 && dimmer3.getState()==0) {
-      dimmer3.setState(ON);
-      logging.Set_log_init("Dimmer3 On\r\n");
-      delay(50);
-      dimmer3.setPower(dimmer3_pwr);
-     }
-     else { dimmer3.setPower(dimmer3_pwr); }
-    }  
-#endif   
+    if ( dimmer3_pwr != dimmer3.getPower() ) {
+      if (dimmer3_pwr == 0 && dimmer3.getState()==1) {
+        dimmer3.setPower(0);
+        dimmer3.setState(OFF);
+        logging.Set_log_init("Dimmer3 Off\r\n");
+        delay(50);
+      }
+      else if (dimmer3_pwr != 0 && dimmer3.getState()==0) {
+        dimmer3.setState(ON);
+        logging.Set_log_init("Dimmer3 On\r\n");
+        delay(50);
+        dimmer3.setPower(dimmer3_pwr);
+      }
+      else { dimmer3.setPower(dimmer3_pwr); }
+    }
+    #endif
     logging.Set_log_init("dimmer 1: " + String(dimmer1_pwr) + "%\r\n" );
     #ifdef outputPin2
     logging.Set_log_init("dimmer 2: " + String(dimmer2_pwr) + "%\r\n" );
     logging.Set_log_init("dimmer 3: " + String(dimmer3_pwr) + "%\r\n" );
     #endif
   #endif
-   }
+  }
 
-//getter
-float get_power(){
-  // pour le ssr 
+  // getter
+  float get_power(){
+    // pour le ssr
     #ifdef SSR_ZC
-      power = ssr_burst.get_power();
+    power = ssr_burst.get_power();
     #endif
 
     #ifdef SSR_RANDOM
-      power = sysvar.puissance;
+    power = sysvar.puissance;
     #endif
 
     // pour le dimmer robotdyn
     #ifdef ROBOTDYN
-      config.calcul_charge();
-      int power1 = dimmer.getPower();
+    config.calcul_charge();
+    int power1 = dimmer.getPower();
       #ifdef outputPin2
-        int power2 = dimmer2.getPower();
-        int power3 = dimmer3.getPower();
-        power = ((float)(power1*config.charge1 + power2*config.charge2 + power3*config.charge3) / (float)config.charge) ;
+    int power2 = dimmer2.getPower();
+    int power3 = dimmer3.getPower();
+    power = ((float)(power1*config.charge1 + power2*config.charge2 + power3*config.charge3) / (float)config.charge);
       #else
-        power = ((float)(power1*config.charge1 ) / (float)config.charge) ;
+    power = ((float)(power1*config.charge1 ) / (float)config.charge);
       #endif
     #endif
-  return power;
-}
+    return power;
+  }
 
-/// @brief  migration des function de coupures des dimmers Robotdyn 
-
-void dimmer_off()
-{
+  /// @brief  migration des function de coupures des dimmers Robotdyn
+  void dimmer_off()
+  {
   #ifdef ROBOTDYN
     if (dimmer.getState()) {
       dimmer.setPower(0);
@@ -169,29 +171,27 @@ void dimmer_off()
       delay(50);
     }
     #ifdef outputPin2
-      if (dimmer2.getState()) {
+    if (dimmer2.getState()) {
       dimmer2.setPower(0);
       dimmer2.setState(OFF);
       logging.Set_log_init("Dimmer2 Off\r\n");
       delay(50);
-}
+    }
     #endif
     #ifdef outputPin3
-      if (dimmer3.getState()) {
-        dimmer3.setPower(0);
-        dimmer3.setState(OFF);
-        logging.Set_log_init("Dimmer3 Off\r\n");
-        delay(50);
-      }
+    if (dimmer3.getState()) {
+      dimmer3.setPower(0);
+      dimmer3.setState(OFF);
+      logging.Set_log_init("Dimmer3 Off\r\n");
+      delay(50);
+    }
     #endif
   #endif
 
   #ifdef SSR_ZC
     ssr_burst.set_power(0);
   #endif
-
-}
-
+  }
 };
 
 #endif

--- a/src/function/web.h
+++ b/src/function/web.h
@@ -17,23 +17,23 @@
 #else
 // Web services
   #include <ESP8266WiFi.h>
-  //#include <ESPAsyncTCP.h>
-  #include <ESP8266HTTPClient.h> 
+// #include <ESPAsyncTCP.h>
+  #include <ESP8266HTTPClient.h>
 #endif
 
 #include "StreamConcat.h"
 
 
-extern Mqtt mqtt_config; 
-extern Config config; 
+extern Mqtt mqtt_config;
+extern Config config;
 extern System sysvar;
-extern Programme programme; 
-extern Programme programme_relay1; 
-extern Programme programme_relay2; 
-extern gestion_puissance unified_dimmer; 
+extern Programme programme;
+extern Programme programme_relay1;
+extern Programme programme_relay2;
+extern gestion_puissance unified_dimmer;
 
 extern DNSServer dns;
-//extern byte security; 
+// extern byte security;
 
 AsyncWebServer server(80);
 
@@ -41,10 +41,10 @@ AsyncWiFiManager wifiManager(&server,&dns);
 
 
 
-extern bool AP; 
+extern bool AP;
 
-extern HA device_dimmer; 
-extern HA device_temp[MAX_DALLAS]; 
+extern HA device_dimmer;
+extern HA device_temp[MAX_DALLAS];
 extern HA device_relay1;
 extern HA device_relay2;
 extern HA device_dimmer_on_off;
@@ -59,12 +59,12 @@ extern String dimmername;
 
 extern DeviceAddress addr[MAX_DALLAS];
 
-constexpr const char* PARAM_INPUT_1 = "POWER"; /// paramettre de retour sendmode
+constexpr const char* PARAM_INPUT_1 = "POWER";  /// paramettre de retour sendmode
 constexpr const char* PARAM_INPUT_2 = "OFFSET"; /// paramettre de retour sendmode
- 
 
-String getmqtt(); 
-String getconfig(); 
+
+String getmqtt();
+String getconfig();
 String getState();
 String getState_dallas();
 
@@ -78,7 +78,7 @@ String getMinuteur(const Programme& minuteur);
 String getMinuteur();
 String replaceSpacesWithHyphens(String input);
 
-extern Logs Logging; 
+extern Logs Logging;
 extern String devAddrNames[MAX_DALLAS];
 
 #ifdef SSR_ZC
@@ -102,132 +102,122 @@ void call_pages() {
   server.serveStatic("/jquery.easing.min.js", LittleFS, "/js/jquery.easing.min.js");
   server.serveStatic("/lang.json", LittleFS, "/lang.json");
 
-
-/// page de index et récupération des requetes de puissance
+  // page de index et récupération des requetes de puissance
   server.on("/",HTTP_ANY, [](AsyncWebServerRequest *request){
-    
+
     if  (LittleFS.exists("/index.html")) {
       DEBUG_PRINTLN(("%d------------------",__LINE__));
       DEBUG_PRINTLN(sysvar.puissance);
-      /// si requete sur POWER
+      // si requete sur POWER
 
 #ifdef DEBUG
       Serial.println("index.html");
-  int paramsCount = request->params();
-  for (int i = 0; i < paramsCount; i++) {
-    AsyncWebParameter *param = request->getParam(i);
-    if (param->isPost()) {
-      Serial.printf("Paramètre POST : %s = %s\n", param->name().c_str(), param->value().c_str());
-    } else {
-      Serial.printf("Paramètre GET : %s = %s\n", param->name().c_str(), param->value().c_str());
-    }
-  }
+      int paramsCount = request->params();
+      for (int i = 0; i < paramsCount; i++) {
+        AsyncWebParameter *param = request->getParam(i);
+        if (param->isPost()) {
+          Serial.printf("Paramètre POST : %s = %s\n", param->name().c_str(), param->value().c_str());
+        } else {
+          Serial.printf("Paramètre GET : %s = %s\n", param->name().c_str(), param->value().c_str());
+        }
+      }
 #endif
 
-      if (request->hasParam(PARAM_INPUT_1)) { 
-
+      if (request->hasParam(PARAM_INPUT_1)) {
         float input=request->getParam(PARAM_INPUT_1)->value().toFloat();
 
-        
-          if (input==0) {
-            sysvar.puissance = 0 ;            // En %
-            //int dispo=0;                          // En % // on ne s'en sert pas, donc commenté
-            sysvar.puissance_dispo = 0;         // En W
-            sysvar.change = 0; // par sécurité, au cas ou le main n'aurait pas fini
+        if (input==0) {
+          sysvar.puissance = 0;         // En %
+          // int dispo=0;               // En % // on ne s'en sert pas, donc commenté
+          sysvar.puissance_dispo = 0;   // En W
+          sysvar.change = 0;            // par sécurité, au cas ou le main n'aurait pas fini
+        }
+
+        /// si remontée de puissance dispo alors prioritaire
+        else if (request->hasParam("puissance")) {
+          /// on recupère la puissance disponible
+          float dispo = request->getParam("puissance")->value().toFloat();
+
+          DEBUG_PRINTLN("puissance="+String(dispo));
+          /// on la converti en pourcentage de charge et config.dispo contient la puissance disponible en W
+          config.dispo = dispo;                 // En W
+          sysvar.puissance_dispo = dispo;       // En W
+          dispo = (100*dispo/config.charge);    // En %
+
+          /// si on dépasse le max, on calcule la puissance dispo restante pour un dimmer enfant
+          if (unified_dimmer.get_power() + dispo >= config.maxpow ) {           // En %
+            sysvar.puissance_dispo =
+              (config.dispo - ((config.maxpow - unified_dimmer.get_power()) * config.charge / 100));    // En W
           }
-                     
-/// si remontée de puissance dispo alors prioritaire
-          else if (request->hasParam("puissance")) {
-/// on recupère la puissance disponible  
-            float dispo = request->getParam("puissance")->value().toFloat();
 
-            DEBUG_PRINTLN("puissance="+String(dispo));
-            /// on la converti en pourcentage de charge et config.dispo contient la puissance disponible en W 
-            config.dispo = dispo;               // En W
-            sysvar.puissance_dispo = dispo;     // En W
-            dispo = (100*dispo/config.charge);  // En %
- 
-            
-              /// si on dépasse le max, on calcule la puissance dispo restante pour un dimmer enfant
-              if (unified_dimmer.get_power() + dispo >= config.maxpow ) {       // En %
-                sysvar.puissance_dispo = (config.dispo - ((config.maxpow - unified_dimmer.get_power()) * config.charge / 100));  // En W
-              }
-
-            // on égalise
-            if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 && strcmp(config.mode,"equal") == 0  ) {
-              if ( (sysvar.security == 1) || (unified_dimmer.get_power() >= config.maxpow) ) {
-                sysvar.puissance = sysvar.puissance + dispo;          // En %
-                sysvar.puissance_dispo = sysvar.puissance_dispo * 2 ; //  En W - On multiplie par 2 car la fonction child_communication() fera / 2
-                              }
-              else { // Mode avec dimmer enfant en equal ET toujours en capacité de router localement de la puissance
-              sysvar.puissance = sysvar.puissance + dispo/2;        // En %
-                  }
-            }
-            else {  // si mode sans dimmer enfant ou en mode délestage vers un fils
+          // on égalise
+          if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 && strcmp(config.mode,"equal") == 0  ) {
+            if ( (sysvar.security == 1) || (unified_dimmer.get_power() >= config.maxpow) ) {
               sysvar.puissance = sysvar.puissance + dispo;            // En %
-                              }
-         }
-         
-         else // uniquement la commande /?POWER= reçue
-         {
-           sysvar.puissance = input;
-                      sysvar.puissance_dispo = 0;
-                      DEBUG_PRINTLN(("%d-input=" + String(input),__LINE__));
-         }
+              sysvar.puissance_dispo = sysvar.puissance_dispo * 2;    // En W - On multiplie par 2 car la fonction child_communication() fera / 2
+            }
+            else {  // Mode avec dimmer enfant en equal ET toujours en capacité de router localement de la puissance
+              sysvar.puissance = sysvar.puissance + dispo/2;        // En %
+            }
+          }
+          else {  // si mode sans dimmer enfant ou en mode délestage vers un fils
+            sysvar.puissance = sysvar.puissance + dispo;              // En %
+          }
+        }
 
-        // si config.child = 0.0.0.0 alors max = 100 
+        else {  // uniquement la commande /?POWER= reçue
+          sysvar.puissance = input;
+          sysvar.puissance_dispo = 0;
+          DEBUG_PRINTLN(("%d-input=" + String(input),__LINE__));
+        }
+
+        // si config.child = 0.0.0.0 alors max = 100
         int max = 200;
-        if (strcmp(config.child,"none") == 0 || strcmp(config.mode,"off") == 0 ) { max = 100; } 
+        if (strcmp(config.child,"none") == 0 || strcmp(config.mode,"off") == 0 ) { max = 100; }
         if (sysvar.puissance >= max) {sysvar.puissance = max; }
         logging.Set_log_init("HTTP power at " + String(sysvar.puissance) + "%\r\n");
-// Modif RV - correction bug si dimmer configuré mais pas allumé ou planté
-        if (sysvar.change == 0) { 
-        sysvar.change=1; 
+        // Modif RV - correction bug si dimmer configuré mais pas allumé ou planté
+        if (sysvar.change == 0) {
+          sysvar.change=1;
         }
-        String pb=getState().c_str(); 
+        String pb=getState().c_str();
         request->send(200, "application/json", pb.c_str() );
-      } 
-      
+      }
+
       else if (request->hasParam(PARAM_INPUT_2)) {
-        config.startingpow = request->getParam(PARAM_INPUT_2)->value().toInt(); 
+        config.startingpow = request->getParam(PARAM_INPUT_2)->value().toInt();
         logging.Set_log_init("HTTP power at " + String(config.startingpow)+"W\r\n");
-        sysvar.change=1; 
+        sysvar.change=1;
         request->send(200, "application/json", getState().c_str());
       }
 
-      else  { 
-            if (!AP) {
-              request->send(LittleFS, "/index.html", String(), false, processor);
-
-            }
-            else {
-              request->send(LittleFS, "/index-AP.html", String(), false, processor);
-            }
-          }
+      else  {
+        if (!AP) {
+          request->send(LittleFS, "/index.html", String(), false, processor);
+        } else {
+          request->send(LittleFS, "/index-AP.html", String(), false, processor);
+        }
+      }
     }
     else
-    { 
+    {
       request->send(200, "text/html", textnofiles().c_str());
     }
-    
+
     DEBUG_PRINTLN(sysvar.puissance);
     DEBUG_PRINTLN(("%d------------------",__LINE__));
-  }); 
+  });
 
-/// page de config et récupération des requetes de config
+  // page de config et récupération des requetes de config
   server.on("/config.html",HTTP_ANY, [](AsyncWebServerRequest *request){
     if  (LittleFS.exists("/config.html")) {
-        if (!AP) {
-            request->send(LittleFS, "/config.html", String(), false, processor);
-
-        }
-        else {
-            request->send(LittleFS, "/config-AP.html", String(), false, processor);
-        }
-
+      if (!AP) {
+        request->send(LittleFS, "/config.html", String(), false, processor);
+      } else {
+        request->send(LittleFS, "/config-AP.html", String(), false, processor);
+      }
     }
-    else
-    { 
+    else {
       request->send(200, "text/html", textnofiles().c_str());
     }
   });
@@ -236,9 +226,7 @@ void call_pages() {
     request->send(200, "application/json", getState().c_str());
   });
 
-
-
-    server.on("/state_dallas", HTTP_ANY, [](AsyncWebServerRequest *request){
+  server.on("/state_dallas", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(200, "application/json", getState_dallas().c_str());
   });
 
@@ -253,19 +241,19 @@ void call_pages() {
     config.restart = true;
   });
 
-    server.on("/disconnect", HTTP_ANY, [](AsyncWebServerRequest *request){
+  server.on("/disconnect", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->redirect("/");
     WiFi.disconnect();
   });
 
   server.on("/ping", HTTP_ANY, [](AsyncWebServerRequest *request){
-    request->send(200, "text/plain", "pong");   
+    request->send(200, "text/plain", "pong");
   });
 
   server.on("/config.json", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(LittleFS, "/config.json", "application/json");
   });
-  
+
   server.on("/mqtt.json", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(LittleFS, "/mqtt.json", "application/json");
   });
@@ -283,62 +271,108 @@ void call_pages() {
   });
 
   server.on("/getminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
-    if (request->hasParam("dimmer")) { request->send(200, "application/json",  getMinuteur(programme));  }
+    if (request->hasParam("dimmer")) { request->send(200, "application/json",  getMinuteur(programme)); }
     else if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
     else if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 
   server.on("/setminuteur", HTTP_ANY, [] (AsyncWebServerRequest *request) {
-    String name; 
-    if (request->hasParam("dimmer")) { 
-            if (request->hasParam("heure_demarrage")) { request->getParam("heure_demarrage")->value().toCharArray(programme.heure_demarrage,6);  }
-            if (request->hasParam("heure_arret")) { request->getParam("heure_arret")->value().toCharArray(programme.heure_arret,6);  }
-            if (request->hasParam("puissance")) { programme.puissance = request->getParam("puissance")->value().toInt(); }
-            if (request->hasParam("temperature")) { programme.temperature = request->getParam("temperature")->value().toInt();  programme.saveProgramme(); }
-       request->send(200, "application/json",  getMinuteur(programme));  
+    String name;
+    if (request->hasParam("dimmer")) {
+      if (request->hasParam("heure_demarrage")) {
+        request->getParam("heure_demarrage")->value().toCharArray(
+          programme.heure_demarrage, 6);
+      }
+      if (request->hasParam("heure_arret")) {
+        request->getParam("heure_arret")->value().toCharArray(
+          programme.heure_arret,6);
+      }
+      if (request->hasParam("puissance")) {
+        programme.puissance = request->getParam("puissance")->value().toInt();
+      }
+      if (request->hasParam("temperature")) {
+        programme.temperature = request->getParam(
+          "temperature")->value().toInt();
+        programme.saveProgramme();
+      }
+      request->send(200, "application/json",  getMinuteur(programme));
     }
-    if (request->hasParam("relay1")) { 
-            if (request->hasParam("heure_demarrage")) { request->getParam("heure_demarrage")->value().toCharArray(programme_relay1.heure_demarrage,6);  }
-            if (request->hasParam("heure_arret")) { request->getParam("heure_arret")->value().toCharArray(programme_relay1.heure_arret,6);  }
-            if (request->hasParam("temperature")) { programme_relay1.temperature = request->getParam("temperature")->value().toInt();  programme_relay1.saveProgramme(); }
-      request->send(200, "application/json",  getMinuteur(programme_relay1)); 
+    if (request->hasParam("relay1")) {
+      if (request->hasParam("heure_demarrage")) {
+        request->getParam("heure_demarrage")->value().toCharArray(
+          programme_relay1.heure_demarrage,6);
+      }
+      if (request->hasParam("heure_arret")) {
+        request->getParam("heure_arret")->value().toCharArray(
+          programme_relay1.heure_arret,6);
+      }
+      if (request->hasParam("temperature")) {
+        programme_relay1.temperature = request->getParam(
+          "temperature")->value().toInt();
+        programme_relay1.saveProgramme();
+      }
+      request->send(200, "application/json", getMinuteur(programme_relay1));
     }
-    if (request->hasParam("relay2")) { 
-            if (request->hasParam("heure_demarrage")) { request->getParam("heure_demarrage")->value().toCharArray(programme_relay2.heure_demarrage,6);  }
-            if (request->hasParam("heure_arret")) { request->getParam("heure_arret")->value().toCharArray(programme_relay2.heure_arret,6);  }
-            if (request->hasParam("temperature")) { programme_relay2.temperature = request->getParam("temperature")->value().toInt();  programme_relay2.saveProgramme(); }
-      request->send(200, "application/json",  getMinuteur(programme_relay2)); 
+    if (request->hasParam("relay2")) {
+      if (request->hasParam("heure_demarrage")) {
+        request->getParam("heure_demarrage")->value().toCharArray(
+          programme_relay2.heure_demarrage,6);
+      }
+      if (request->hasParam("heure_arret")) {
+        request->getParam("heure_arret")->value().toCharArray(
+          programme_relay2.heure_arret,6);
+      }
+      if (request->hasParam("temperature")) {
+        programme_relay2.temperature = request->getParam(
+          "temperature")->value().toInt();  programme_relay2.saveProgramme();
+      }
+      request->send(200, "application/json",  getMinuteur(programme_relay2));
     }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 
   /// reglage des seuils relais
-
-    server.on("/getseuil", HTTP_ANY, [] (AsyncWebServerRequest *request) {
+  server.on("/getseuil", HTTP_ANY, [] (AsyncWebServerRequest *request) {
     if (request->hasParam("relay1")) { request->send(200, "application/json",  getMinuteur(programme_relay1)); }
     else if (request->hasParam("relay2")) { request->send(200, "application/json",  getMinuteur(programme_relay2)); }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
 
   server.on("/setseuil", HTTP_ANY, [] (AsyncWebServerRequest *request) {
-    String name; 
-    if (request->hasParam("relay1")) { 
-            if (request->hasParam("seuil_demarrage")) { programme_relay1.seuil_start =request->getParam("seuil_demarrage")->value().toInt();   }
-            if (request->hasParam("seuil_arret")) { programme_relay1.seuil_stop =request->getParam("seuil_arret")->value().toInt();   }
-            if (request->hasParam("temperature")) { programme_relay1.seuil_temperature = request->getParam("temperature")->value().toInt();  programme_relay1.saveProgramme(); }
-      request->send(200, "application/json",  getMinuteur(programme_relay1)); 
+    String name;
+    if (request->hasParam("relay1")) {
+      if (request->hasParam("seuil_demarrage")) {
+        programme_relay1.seuil_start =request->getParam(
+          "seuil_demarrage")->value().toInt();
+      }
+      if (request->hasParam("seuil_arret")) {
+        programme_relay1.seuil_stop =request->getParam(
+          "seuil_arret")->value().toInt();
+      }
+      if (request->hasParam("temperature")) {
+        programme_relay1.seuil_temperature = request->getParam(
+          "temperature")->value().toInt();  programme_relay1.saveProgramme();
+      }
+      request->send(200, "application/json",  getMinuteur(programme_relay1));
     }
-    if (request->hasParam("relay2")) { 
-            if (request->hasParam("seuil_demarrage")) { programme_relay2.seuil_start = request->getParam("seuil_demarrage")->value().toInt();   }
-            if (request->hasParam("seuil_arret")) { programme_relay2.seuil_stop = request->getParam("seuil_arret")->value().toInt();   }
-            if (request->hasParam("temperature")) { programme_relay2.seuil_temperature = request->getParam("temperature")->value().toInt();  programme_relay2.saveProgramme(); }
-      request->send(200, "application/json",  getMinuteur(programme_relay2)); 
+    if (request->hasParam("relay2")) {
+      if (request->hasParam("seuil_demarrage")) {
+        programme_relay2.seuil_start = request->getParam(
+          "seuil_demarrage")->value().toInt();
+      }
+      if (request->hasParam("seuil_arret")) {
+        programme_relay2.seuil_stop = request->getParam(
+          "seuil_arret")->value().toInt();
+      }
+      if (request->hasParam("temperature")) {
+        programme_relay2.seuil_temperature = request->getParam(
+          "temperature")->value().toInt();  programme_relay2.saveProgramme();
+      }
+      request->send(200, "application/json",  getMinuteur(programme_relay2));
     }
     else { request->send(200, "application/json",  getMinuteur()); }
   });
-
-
 
   server.on("/config", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(200, "application/json", getconfig().c_str());
@@ -352,23 +386,22 @@ void call_pages() {
   server.on("/cs", HTTP_ANY, [](AsyncWebServerRequest *request){
     logging.Set_log_init("}1");
     request->send(200, "text/plain", logging.Get_log_init().c_str());
-    // reinit de logging.log_init 
-    logging.reset_log_init(); 
+    // reinit de logging.log_init
+    logging.reset_log_init();
   });
 
   server.on("/onoff", HTTP_ANY, [](AsyncWebServerRequest *request){
-      getServermode("ONOFF");
-      request->send(200, "text/html", config.dimmer_on_off ? "1" : "0");
+    getServermode("ONOFF");
+    request->send(200, "text/html", config.dimmer_on_off ? "1" : "0");
   });
 
-
   server.on("/save", HTTP_ANY, [](AsyncWebServerRequest *request){
-      request->send(LittleFS, "/config.json", String(), true);
+    request->send(LittleFS, "/config.json", String(), true);
   });
 
   server.on("/readmqtt", HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(200, "text/html", readmqttsave().c_str());
-    });
+  });
 
 
 
@@ -377,313 +410,331 @@ void call_pages() {
 ////// mise à jour parametre d'envoie vers domoticz et récupération des modifications de configurations
 /////////////////////////
 
-server.on("/get", HTTP_ANY, [] (AsyncWebServerRequest *request) {
-      ///  fonction  /get?paramettre=xxxx
-    if (request->hasParam("save")) { Serial.println(F("Saving configuration..."));
-                          logging.Set_log_init(config.saveConfiguration());    //sauvegarde de la configuration
-                            }
-                          
-   if (request->hasParam("hostname")) { request->getParam("hostname")->value().toCharArray(config.hostname,16);  }
-   if (request->hasParam("port")) { config.port = request->getParam("port")->value().toInt();}
-   if (request->hasParam("Publish")) { request->getParam("Publish")->value().toCharArray(config.Publish,100);}
-   if (request->hasParam("idxtemp")) { config.IDXTemp = request->getParam("idxtemp")->value().toInt();}
-   if (request->hasParam("maxtemp")) { 
-    config.maxtemp = request->getParam("maxtemp")->value().toInt();
-    if (!AP && mqtt_config.mqtt) { device_dimmer_maxtemp.send(String(config.maxtemp));}
-   }
-if (request->hasParam("charge1")) { 
-    config.charge1 = request->getParam("charge1")->value().toInt(); 
-    config.charge = config.charge1 + config.charge2 + config.charge3;
+  server.on("/get", HTTP_ANY, [] (AsyncWebServerRequest *request) {
+    ///  fonction  /get?paramettre=xxxx
+    if (request->hasParam("save")) {
+      Serial.println(F("Saving configuration..."));
+      logging.Set_log_init(config.saveConfiguration()); // sauvegarde de la configuration
     }
-   if (request->hasParam("charge2")) { 
-    config.charge2 = request->getParam("charge2")->value().toInt(); 
-    config.charge = config.charge1 + config.charge2 + config.charge3;
+
+    if (request->hasParam("hostname")) { request->getParam("hostname")->value().toCharArray(config.hostname,16); }
+    if (request->hasParam("port")) { config.port = request->getParam("port")->value().toInt();  }
+    if (request->hasParam("Publish")) { request->getParam("Publish")->value().toCharArray(config.Publish,100); }
+    if (request->hasParam("idxtemp")) { config.IDXTemp = request->getParam("idxtemp")->value().toInt(); }
+    if (request->hasParam("maxtemp")) {
+      config.maxtemp = request->getParam("maxtemp")->value().toInt();
+      if (!AP && mqtt_config.mqtt) { device_dimmer_maxtemp.send(String(config.maxtemp));}
     }
-   if (request->hasParam("charge3")) { 
-    config.charge3 = request->getParam("charge3")->value().toInt(); 
-    config.charge = config.charge1 + config.charge2 + config.charge3;
+    if (request->hasParam("charge1")) {
+      config.charge1 = request->getParam("charge1")->value().toInt();
+      config.charge = config.charge1 + config.charge2 + config.charge3;
     }
-   if (request->hasParam("IDXAlarme")) { config.IDXAlarme = request->getParam("IDXAlarme")->value().toInt();}
-   if (request->hasParam("IDX")) { config.IDX = request->getParam("IDX")->value().toInt();}
-   if (request->hasParam("startingpow")) { config.startingpow = request->getParam("startingpow")->value().toInt();
-    if (!AP && mqtt_config.mqtt) { device_dimmer_starting_pow.send(String(config.startingpow));}
-   }
-   if (request->hasParam("minpow")) { 
-    config.minpow = request->getParam("minpow")->value().toInt();
-    if (!AP && mqtt_config.mqtt) { device_dimmer_minpow.send(String(config.minpow));}
-   }
-   if (request->hasParam("maxpow")) { 
-    config.maxpow = request->getParam("maxpow")->value().toInt();
-    if (!AP && mqtt_config.mqtt) { device_dimmer_maxpow.send(String(config.maxpow));}
-   }
-
-   if (request->hasParam("child")) { request->getParam("child")->value().toCharArray(config.child,64);  }
-   if (request->hasParam("mode")) { 
-    request->getParam("mode")->value().toCharArray(config.mode,10);  
-    if (!AP && mqtt_config.mqtt) { device_dimmer_child_mode.send(String(config.mode));}
-   }
-
-   if (request->hasParam("dimmername")) { request->getParam("dimmername")->value().toCharArray(config.say_my_name,100);
-   String temp_dimmer_name = replaceSpacesWithHyphens(config.say_my_name);
-    // copie du nom du dimmer dans le nom de l'entité
-    temp_dimmer_name.toCharArray(config.say_my_name,100);
-   }
-   if (request->hasParam("SubscribePV")) { request->getParam("SubscribePV")->value().toCharArray(config.SubscribePV,100);}
-   if (request->hasParam("SubscribeTEMP")) { request->getParam("SubscribeTEMP")->value().toCharArray(config.SubscribeTEMP,100);}
-   if (request->hasParam("dimmer_on_off")) { 
-    config.dimmer_on_off = request->getParam("dimmer_on_off")->value().toInt();
-    if (!AP && mqtt_config.mqtt) { device_dimmer_on_off.send(String(config.dimmer_on_off));}
-   }
-   if (request->hasParam("mqttuser")) { request->getParam("mqttuser")->value().toCharArray(mqtt_config.username,50);  }
-   if (request->hasParam("mqttpassword")) { 
-    request->getParam("mqttpassword")->value().toCharArray(mqtt_config.password,50);
-    logging.Set_log_init(config.saveConfiguration()); //sauvegarde de la configuration
-    logging.Set_log_init(mqtt_config.savemqtt());  // sauvegarde et récupération de la log MQTT
-   }
-   if (request->hasParam("DALLAS")) { 
-    request->getParam("DALLAS")->value().toCharArray(config.DALLAS,17); 
-    // application de la modification sur la dallas master si existante
-    for (int i = 0; i < MAX_DALLAS; i++) {
-      if (strcmp(config.DALLAS,(devAddrNames[i]).c_str() ) == 0) { sysvar.dallas_maitre = i; }
-    
+    if (request->hasParam("charge2")) {
+      config.charge2 = request->getParam("charge2")->value().toInt();
+      config.charge = config.charge1 + config.charge2 + config.charge3;
     }
-   }
+    if (request->hasParam("charge3")) {
+      config.charge3 = request->getParam("charge3")->value().toInt();
+      config.charge = config.charge1 + config.charge2 + config.charge3;
+    }
+    if (request->hasParam("IDXAlarme")) { config.IDXAlarme = request->getParam("IDXAlarme")->value().toInt(); }
+    if (request->hasParam("IDX")) { config.IDX = request->getParam("IDX")->value().toInt(); }
+    if (request->hasParam("startingpow")) {
+      config.startingpow = request->getParam("startingpow")->value().toInt();
+      if (!AP && mqtt_config.mqtt) {
+        device_dimmer_starting_pow.send(
+          String(config.startingpow));
+      }
+    }
+    if (request->hasParam("minpow")) {
+      config.minpow = request->getParam("minpow")->value().toInt();
+      if (!AP && mqtt_config.mqtt) { device_dimmer_minpow.send(String(config.minpow)); }
+    }
+    if (request->hasParam("maxpow")) {
+      config.maxpow = request->getParam("maxpow")->value().toInt();
+      if (!AP && mqtt_config.mqtt) { device_dimmer_maxpow.send(String(config.maxpow)); }
+    }
 
-//// minuteur 
-   if (request->hasParam("heure_demarrage")) { request->getParam("heure_demarrage")->value().toCharArray(programme.heure_demarrage,6);  }
-   if (request->hasParam("heure_arret")) { request->getParam("heure_arret")->value().toCharArray(programme.heure_arret,6);  }
-   if (request->hasParam("temperature")) { programme.temperature = request->getParam("temperature")->value().toInt();  programme.saveProgramme(); }
+    if (request->hasParam("child")) { request->getParam("child")->value().toCharArray(config.child,64); }
+    if (request->hasParam("mode")) {
+      request->getParam("mode")->value().toCharArray(config.mode,10);
+      if (!AP && mqtt_config.mqtt) { device_dimmer_child_mode.send(String(config.mode)); }
+    }
 
-// trigger
-   if (request->hasParam("trigger")) { config.trigger = request->getParam("trigger")->value().toInt();}
+    if (request->hasParam("dimmername")) {
+      request->getParam("dimmername")->value().toCharArray(config.say_my_name,100);
+      String temp_dimmer_name = replaceSpacesWithHyphens(config.say_my_name);
+      // copie du nom du dimmer dans le nom de l'entité
+      temp_dimmer_name.toCharArray(config.say_my_name,100);
+    }
+    if (request->hasParam("SubscribePV")) {
+      request->getParam("SubscribePV")->value().toCharArray(
+        config.SubscribePV, 100);
+    }
+    if (request->hasParam("SubscribeTEMP")) {
+      request->getParam("SubscribeTEMP")->value().toCharArray(
+        config.SubscribeTEMP, 100);
+    }
+    if (request->hasParam("dimmer_on_off")) {
+      config.dimmer_on_off = request->getParam("dimmer_on_off")->value().toInt();
+      if (!AP && mqtt_config.mqtt) { device_dimmer_on_off.send(String(config.dimmer_on_off));}
+    }
+    if (request->hasParam("mqttuser")) { request->getParam("mqttuser")->value().toCharArray(mqtt_config.username,50); }
+    if (request->hasParam("mqttpassword")) {
+      request->getParam("mqttpassword")->value().toCharArray(mqtt_config.password,50);
+      logging.Set_log_init(config.saveConfiguration()); // sauvegarde de la configuration
+      logging.Set_log_init(mqtt_config.savemqtt()); // sauvegarde et récupération de la log MQTT
+    }
+    if (request->hasParam("DALLAS")) {
+      request->getParam("DALLAS")->value().toCharArray(config.DALLAS,17);
+      // application de la modification sur la dallas master si existante
+      for (int i = 0; i < MAX_DALLAS; i++) {
+        if (strcmp(config.DALLAS,(devAddrNames[i]).c_str() ) == 0) { sysvar.dallas_maitre = i; }
+      }
+    }
+
+    // minuteur
+    if (request->hasParam("heure_demarrage")) {
+      request->getParam("heure_demarrage")->value().toCharArray(
+        programme.heure_demarrage, 6);
+    }
+    if (request->hasParam("heure_arret")) {
+      request->getParam("heure_arret")->value().toCharArray(
+        programme.heure_arret, 6);
+    }
+    if (request->hasParam("temperature")) {
+      programme.temperature = request->getParam(
+        "temperature")->value().toInt();  programme.saveProgramme();
+    }
+
+    // trigger
+    if (request->hasParam("trigger")) { config.trigger = request->getParam("trigger")->value().toInt();}
 
 
-  //Ajout des relais
-
+    // Ajout des relais
   #ifdef RELAY1
     if (request->hasParam("relay1")) {
-        int relay = request->getParam("relay1")->value().toInt();
-        if ( relay == 0) { digitalWrite(RELAY1 , LOW); }
-        else if (relay == 1) { digitalWrite(RELAY1 , HIGH); } 
-        else if (relay == 2) { digitalWrite(RELAY1, !digitalRead(RELAY1)); }
-        int relaystate = digitalRead(RELAY1); 
-        char str[8];// NOSONAR
-        itoa( relaystate, str, 10 );
-        request->send(200, "application/json", str );
-        if (!AP && mqtt_config.mqtt) { device_relay1.send(String(relaystate));}
-        return;
+      int relay = request->getParam("relay1")->value().toInt();
+      if ( relay == 0) { digitalWrite(RELAY1, LOW); }
+      else if (relay == 1) { digitalWrite(RELAY1, HIGH); }
+      else if (relay == 2) { digitalWrite(RELAY1, !digitalRead(RELAY1)); }
+      int relaystate = digitalRead(RELAY1);
+      char str[8];  // NOSONAR
+      itoa( relaystate, str, 10 );
+      request->send(200, "application/json", str );
+      if (!AP && mqtt_config.mqtt) { device_relay1.send(String(relaystate));}
+      return;
     }
   #endif
   #ifdef RELAY2
     if (request->hasParam("relay2")) {
-        int relay = request->getParam("relay2")->value().toInt();
-        if ( relay == 0) { digitalWrite(RELAY2 , LOW); }
-        else if (relay == 1) { digitalWrite(RELAY2 , HIGH); } 
-        else if (relay == 2) { digitalWrite(RELAY2, !digitalRead(RELAY2)); }
-        int relaystate = digitalRead(RELAY2); 
-        char str[8];// NOSONAR
-        itoa( relaystate, str, 10 );
-        request->send(200, "application/json", str );
-        if (!AP && mqtt_config.mqtt) { device_relay2.send(String(relaystate));}
-        return;
+      int relay = request->getParam("relay2")->value().toInt();
+      if ( relay == 0) { digitalWrite(RELAY2, LOW); }
+      else if (relay == 1) { digitalWrite(RELAY2, HIGH); }
+      else if (relay == 2) { digitalWrite(RELAY2, !digitalRead(RELAY2)); }
+      int relaystate = digitalRead(RELAY2);
+      char str[8];  // NOSONAR
+      itoa( relaystate, str, 10 );
+      request->send(200, "application/json", str );
+      if (!AP && mqtt_config.mqtt) { device_relay2.send(String(relaystate));}
+      return;
     }
-  #endif 
+  #endif
 
-  //// for check boxs in web pages
-  if (request->hasParam("servermode")) {
-    String inputMessage = request->getParam("servermode")->value();
-    getServermode(inputMessage);
-    logging.Set_log_init(config.saveConfiguration()); //sauvegarde de la configuration
-    logging.Set_log_init(mqtt_config.savemqtt());  // sauvegarde et récupération de la log MQTT
-  }
+    //// for check boxs in web pages
+    if (request->hasParam("servermode")) {
+      String inputMessage = request->getParam("servermode")->value();
+      getServermode(inputMessage);
+      logging.Set_log_init(config.saveConfiguration()); // sauvegarde de la configuration
+      logging.Set_log_init(mqtt_config.savemqtt()); // sauvegarde et récupération de la log MQTT
+    }
 
-  request->send(200, "application/json", getconfig().c_str());
+    request->send(200, "application/json", getconfig().c_str());
   });
 
 }
 
 
-/// @brief Pages de traitement 
-/// @return 
+/// @brief Pages de traitement
+/// @return
 
 String getState_dallas() {
-  String state; 
+  String state;
   char buffer[5];// NOSONAR
-   
-  dtostrf(sysvar.celsius[sysvar.dallas_maitre],2, 1, buffer); // conversion en n.1f 
-  
+
+  dtostrf(sysvar.celsius[sysvar.dallas_maitre],2, 1, buffer); // conversion en n.1f
+
   JsonDocument doc;
-    doc["temperature"] = buffer;
-    
-    //affichage des température et adresse des sondes dallas 
-    for (int i = 0; i < MAX_DALLAS; i++) {
-      char buffer[5];// NOSONAR
-      // affichage que si != 0 
-      if (sysvar.celsius[i] != 0) {
-        dtostrf(sysvar.celsius[i],2, 1, buffer); // conversion en n.1f 
-        doc["dallas"+String(i)] = buffer;
-        doc["addr"+String(i)] = devAddrNames[i];
-      }
+  doc["temperature"] = buffer;
+
+  // affichage des température et adresse des sondes dallas
+  for (int i = 0; i < MAX_DALLAS; i++) {
+    char buffer[5];  // NOSONAR
+    // affichage que si != 0
+    if (sysvar.celsius[i] != 0) {
+      dtostrf(sysvar.celsius[i],2, 1, buffer);   // conversion en n.1f
+      doc["dallas"+String(i)] = buffer;
+      doc["addr"+String(i)] = devAddrNames[i];
     }
+  }
   serializeJson(doc, state);
   return String(state);
 }
 
 
 String getState() {
-  String state; 
+  String state;
   char buffer[5];// NOSONAR
   #ifdef  SSR
     #ifdef SSR_ZC
-      int instant_power= unified_dimmer.get_power(); 
+  int instant_power= unified_dimmer.get_power();
     #else
-      int instant_power= sysvar.puissance ;
+  int instant_power= sysvar.puissance;
     #endif
   #else
-  float instant_power= unified_dimmer.get_power(); 
+  float instant_power= unified_dimmer.get_power();
   #endif
 
-   
-  dtostrf(sysvar.celsius[sysvar.dallas_maitre],2, 1, buffer); // conversion en n.1f 
-  
+  dtostrf(sysvar.celsius[sysvar.dallas_maitre],2, 1, buffer); // conversion en n.1f
+
   JsonDocument doc;
-    doc["dimmer"] = int(instant_power); // on le repasse un int pour éviter un affichage trop grand
-    doc["commande"] = int(sysvar.puissance);
-    doc["temperature"] = buffer;
-    doc["power"] = int(instant_power * config.charge/100);
-    doc["Ptotal"]  = sysvar.puissance_cumul + int(instant_power * config.charge/100);
-    // recupération de l'état de surchauffe
-    doc["alerte"]  = sysvar.security;
-#ifdef RELAY1    
-    doc["relay1"]   = digitalRead(RELAY1);
-    doc["relay2"]   = digitalRead(RELAY2);
+  doc["dimmer"] = int(instant_power);   // on le repasse un int pour éviter un affichage trop grand
+  doc["commande"] = int(sysvar.puissance);
+  doc["temperature"] = buffer;
+  doc["power"] = int(instant_power * config.charge/100);
+  doc["Ptotal"]  = sysvar.puissance_cumul + int(instant_power * config.charge/100);
+  // recupération de l'état de surchauffe
+  doc["alerte"]  = sysvar.security;
+#ifdef RELAY1
+  doc["relay1"]   = digitalRead(RELAY1);
+  doc["relay2"]   = digitalRead(RELAY2);
 #else
-    doc["relay1"]   = 0;
-    doc["relay2"]   = 0;
+  doc["relay1"]   = 0;
+  doc["relay2"]   = 0;
 #endif
-    doc["minuteur"] = programme.run;
-    doc["onoff"] = config.dimmer_on_off;
-    doc["alerte"] = logging.Get_alerte_web();
+  doc["minuteur"] = programme.run;
+  doc["onoff"] = config.dimmer_on_off;
+  doc["alerte"] = logging.Get_alerte_web();
   serializeJson(doc, state);
   return String(state);
 }
 
 String textnofiles() {
-  String state = "<html><body>Filesystem is not present. <a href='https://ota.apper-solaire.org/firmware/littlefs-dimmer.bin'>download it here</a> <br>and after  <a href='/update'>upload on the ESP here </a></body></html>" ; 
+  String state =
+    "<html><body>Filesystem is not present. <a href='https://ota.apper-solaire.org/firmware/littlefs-dimmer.bin'>download it here</a> <br>and after  <a href='/update'>upload on the ESP here </a></body></html>";
   return String(state);
 }
 
 String processor(const String& var){
 
-  if (var == "VERSION"){
+  if (var == "VERSION") {
     // affichage de la version et de l'environnement
-    String VERSION_http = String(VERSION) + " " + String(COMPILE_NAME) ; 
+    String VERSION_http = String(VERSION) + " " + String(COMPILE_NAME);
     return (VERSION_http);
-  } 
-  if (var == "NAME"){
+  }
+  if (var == "NAME") {
     String name = String(config.say_my_name) + ".local";
     return (name);
-  } 
-  if (var == "RSSI"){
+  }
+  if (var == "RSSI") {
     return (String(WiFi.RSSI()));
-  } 
+  }
   return ("N/A");
-} 
+}
 
 
 String getconfig() {
-  String configweb;  
-  JsonDocument doc;  
-    doc["maxtemp"] = config.maxtemp;
+  String configweb;
+  JsonDocument doc;
+  doc["maxtemp"] = config.maxtemp;
 
-    doc["startingpow"] = config.startingpow;
-    doc["minpow"] = config.minpow;
-    doc["maxpow"] = config.maxpow;
+  doc["startingpow"] = config.startingpow;
+  doc["minpow"] = config.minpow;
+  doc["maxpow"] = config.maxpow;
 
-    doc["child"] = config.child;
-    doc["delester"] = config.mode;
+  doc["child"] = config.child;
+  doc["delester"] = config.mode;
 
-    doc["SubscribePV"] = config.SubscribePV;
-    doc["SubscribeTEMP"] = config.SubscribeTEMP;
-    doc["dimmer_on_off"] = config.dimmer_on_off;
-    doc["charge"] = config.charge;
-    doc["DALLAS"] = config.DALLAS;
-    doc["dimmername"] = config.say_my_name;
-    doc["charge1"] = config.charge1;
-    doc["charge2"] = config.charge2;
-    doc["charge3"] = config.charge3;
-    doc["trigger"] = config.trigger;
-  
+  doc["SubscribePV"] = config.SubscribePV;
+  doc["SubscribeTEMP"] = config.SubscribeTEMP;
+  doc["dimmer_on_off"] = config.dimmer_on_off;
+  doc["charge"] = config.charge;
+  doc["DALLAS"] = config.DALLAS;
+  doc["dimmername"] = config.say_my_name;
+  doc["charge1"] = config.charge1;
+  doc["charge2"] = config.charge2;
+  doc["charge3"] = config.charge3;
+  doc["trigger"] = config.trigger;
+
   serializeJson(doc, configweb);
   return String(configweb);
 }
 
 String getMinuteur(const Programme& minuteur ) {
-    getLocalTime(&timeinfo);
-    JsonDocument doc;
-    doc["heure_demarrage"] = minuteur.heure_demarrage;
-    doc["heure_arret"] = minuteur.heure_arret;
-    doc["temperature"] = minuteur.temperature;
-    doc["heure"] = timeinfo.tm_hour;
-    doc["minute"] = timeinfo.tm_min;
-    doc["seuil_start"] = minuteur.seuil_start;
-    doc["seuil_stop"] = minuteur.seuil_stop;
-    doc["seuil_temp"] = minuteur.seuil_temperature;
-    doc["puissance"] = minuteur.puissance;
-
-    String retour;
-    serializeJson(doc, retour);
-    return retour;
+  getLocalTime(&timeinfo);
+  JsonDocument doc;
+  doc["heure_demarrage"] = minuteur.heure_demarrage;
+  doc["heure_arret"] = minuteur.heure_arret;
+  doc["temperature"] = minuteur.temperature;
+  doc["heure"] = timeinfo.tm_hour;
+  doc["minute"] = timeinfo.tm_min;
+  doc["seuil_start"] = minuteur.seuil_start;
+  doc["seuil_stop"] = minuteur.seuil_stop;
+  doc["seuil_temp"] = minuteur.seuil_temperature;
+  doc["puissance"] = minuteur.puissance;
+  String retour;
+  serializeJson(doc, retour);
+  return retour;
 }
 
 String getMinuteur() {
-    getLocalTime(&timeinfo);
-    JsonDocument doc;
-    doc["heure"] = timeinfo.tm_hour;
-    doc["minute"] = timeinfo.tm_min;
-    String retour;
-    serializeJson(doc, retour);
-    return retour;
+  getLocalTime(&timeinfo);
+  JsonDocument doc;
+  doc["heure"] = timeinfo.tm_hour;
+  doc["minute"] = timeinfo.tm_min;
+  String retour;
+  serializeJson(doc, retour);
+  return retour;
 }
 
 String getmqtt() {
-    String retour;
-  JsonDocument doc; 
-
-    doc["server"] = config.hostname;
-    doc["port"] = config.port;
-    doc["topic"] = config.Publish;
-    doc["user"] = mqtt_config.username;
-    doc["password"] = mqtt_config.password;
-    doc["MQTT"] = mqtt_config.mqtt;
-    doc["HA"] = config.HA;
-    doc["JEEDOM"] = config.JEEDOM;
-    doc["DOMOTICZ"] = config.DOMOTICZ;
-    doc["IDX"] = config.IDX;
-    doc["idxtemp"] = config.IDXTemp;
-    doc["IDXAlarme"] = config.IDXAlarme;
+  String retour;
+  JsonDocument doc;
+  doc["server"] = config.hostname;
+  doc["port"] = config.port;
+  doc["topic"] = config.Publish;
+  doc["user"] = mqtt_config.username;
+  doc["password"] = mqtt_config.password;
+  doc["MQTT"] = mqtt_config.mqtt;
+  doc["HA"] = config.HA;
+  doc["JEEDOM"] = config.JEEDOM;
+  doc["DOMOTICZ"] = config.DOMOTICZ;
+  doc["IDX"] = config.IDX;
+  doc["idxtemp"] = config.IDXTemp;
+  doc["IDXAlarme"] = config.IDXAlarme;
   serializeJson(doc, retour);
-  return String(retour) ;
+  return String(retour);
 }
 
 String getcomplement() {
   String retour;
-  JsonDocument doc; 
+  JsonDocument doc;
 
-    doc["hdebut"] = config.hostname;
-    doc["hfin"] = config.port;
-    doc["tmax"] = config.maxtemp;
+  doc["hdebut"] = config.hostname;
+  doc["hfin"] = config.port;
+  doc["tmax"] = config.maxtemp;
 
   serializeJson(doc, retour);
-  return String(retour) ;
+  return String(retour);
 }
 
 
 String readmqttsave(){
-        String node_id = config.say_my_name;
-        String save_command = String("Xlyric/sauvegarde/"+ node_id );
-        client.subscribe(save_command.c_str(),1);
-        return String("<html><head><meta http-equiv='refresh' content='5;url=config.html' /></head><body><h1>config restauree, retour au setup dans 5 secondes, pensez a sauvegarder sur la flash </h1></body></html>");
+  String node_id = config.say_my_name;
+  String save_command = String("Xlyric/sauvegarde/"+ node_id );
+  client.subscribe(save_command.c_str(),1);
+  return String(
+    "<html><head><meta http-equiv='refresh' content='5;url=config.html' /></head><body><h1>config restauree, retour au setup dans 5 secondes, pensez a sauvegarder sur la flash </h1></body></html>");
 }
 
 String getServermode(String Servermode) {
@@ -693,7 +744,7 @@ String getServermode(String Servermode) {
   if ( Servermode == "DOMOTICZ" ) {   config.DOMOTICZ = !config.DOMOTICZ; }
   if ( Servermode == "ONOFF" ) {   config.dimmer_on_off = !config.dimmer_on_off; }
 
-return String(Servermode);
+  return String(Servermode);
 }
 
 String replaceSpacesWithHyphens(String input) {

--- a/src/langues/lang_fr.h
+++ b/src/langues/lang_fr.h
@@ -1,4 +1,5 @@
-#define FAIL_CONF "impossible d'ouvrir le fichier de configuration en écriture dans la fonction Enregistrer la configuration"
+#define FAIL_CONF \
+  "impossible d'ouvrir le fichier de configuration en écriture dans la fonction Enregistrer la configuration"
 #define mDNS_Responder_Started "mDNS responder démarré \r\n"
 #define Reason_for_reset "-- Raison du redémarrage: "
 #define Start_filesystem "Démarrage du système de fichiers \r\n"
@@ -26,7 +27,7 @@
 #define FS_version_is_missing "FS version manquante, veuillez mettre à jour"
 #define FS_version_is_not_same "La version du FS n'est pas à jour\r\n"
 #define FS_version_is_same "La version du FS est à jour\r\n"
-#define Failed_write_wifi_config "Impossible d'écrire la configuration wifi\r\n"   
+#define Failed_write_wifi_config "Impossible d'écrire la configuration wifi\r\n"
 #define Clear_alarm_temp "retrait de l'alarme de température \r\n"
 #define Subscribe_MQTT "S'abonner et publier sur les sujets MQTT\r\n"
 #define Dallas_sensor "Capteur Dallas "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
-/**************
- *  numeric Dimmer  ( using robodyn dimmer = 
+/************************************************************************
+ *  numeric Dimmer  ( using robodyn dimmer =
  *  **************
  *  Upgraded By Cyril Poissonnier 2020
- * 
-  *    
- * 
+ *
+ *
+ *
  *  ---------------------- OUTPUT & INPUT Pin table ---------------------
  *  +---------------+-------------------------+-------------------------+
  *  |   Board       | INPUT Pin               | OUTPUT Pin              |
@@ -50,19 +50,19 @@
  *  | BluePill      |                         |                         |
  *  | Etc...        |                         |                         |
  *  +---------------+-------------------------+-------------------------+
- *  
- *  
+ *
+ *
  *  Work for dimmer on Domoticz or Web command :
- *  http://URL/?POWER=XX 
- *  0 -> 99 
- *  more than 99 = 99  
- *    
- *  Update 2019 04 28 
- *  correct issue full power for many seconds at start 
- *  Update 2020 01 13 
+ *  http://URL/?POWER=XX
+ *  0 -> 99
+ *  more than 99 = 99
+ *
+ *  Update 2019 04 28
+ *  correct issue full power for many seconds at start
+ *  Update 2020 01 13
  *  Version 2 with cute web interface
- *  V2.1    with temperature security ( dallas 18b20 ) 
- *          MQTT to Domoticz for temp 
+ *  V2.1    with temperature security ( dallas 18b20 )
+ *          MQTT to Domoticz for temp
  */
 
 /***************************
@@ -71,15 +71,15 @@
 
 #include <Arduino.h>
 
-//#include "Arduino.h"
+// #include "Arduino.h"
 
 
 #ifdef ROBOTDYN
-  // Dimmer librairy 
+// Dimmer librairy
   #include <RBDdimmer.h>   /// the corrected librairy  in personal depot , the original has a bug
 #endif
 // Web services
-#include <ESPAsyncWiFiManager.h> 
+#include <ESPAsyncWiFiManager.h>
 #include <ESPAsyncWebServer.h>
 
 #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
@@ -92,23 +92,23 @@
 // Dallas 18b20
 #include <OneWire.h>
 #include <DallasTemperature.h>
-//mqtt
-  #include <PubSubClient.h>
+// mqtt
+#include <PubSubClient.h>
 /// config
 #include "langues/lang.h"
 #include "config/config.h"
 #include "config/enums.h"
 #include "function/web.h"
 #include "function/ha.h"
-#include "function/littlefs.h" 
+#include "function/littlefs.h"
 #include "function/mqtt.h"
 #include "function/minuteur.h"
 
 /*
-extern "C" {
-#include "user_interface.h"
-}
-*/
+   extern "C" {
+ #include "user_interface.h"
+   }
+ */
 
 #ifdef ROBOTDYN
   #include "function/dimmer.h"
@@ -134,7 +134,7 @@ extern "C" {
 // File System
   #include <FS.h>
   #include "SPIFFS.h"
-  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct? 
+  #define LittleFS SPIFFS // Fonctionne, mais est-ce correct?
   #include <esp_system.h>
   #include <ESPmDNS.h>
 
@@ -142,8 +142,8 @@ extern "C" {
 // Web services
   #include <ESP8266WiFi.h>
   #include <ESP8266mDNS.h>
-  //#include <ESPAsyncTCP.h>
-  #include <ESP8266HTTPClient.h> 
+// #include <ESPAsyncTCP.h>
+  #include <ESP8266HTTPClient.h>
 // File System
   #include <LittleFS.h> // NOSONAR
 
@@ -160,7 +160,7 @@ Task Task_GET_POWER(10000, TASK_FOREVER, &get_dimmer_child_power);
 #ifdef RELAY1
 Task Task_relay(20000, TASK_FOREVER, &relais_controle);
 #endif
-/// @brief  task de ping 
+/// @brief  task de ping
 Task Task_ping(120000, TASK_FOREVER, &ping);
 Scheduler runner;
 
@@ -184,19 +184,18 @@ bool mqttConnected = false;
 DNSServer dns;
 HTTPClient http;
 bool shouldSaveConfig = false;
-Wifi_struct wifi_config_fixe; 
-
+Wifi_struct wifi_config_fixe;
 
 
 //***********************************
 //************* Time
 //***********************************
-int timesync = 0; 
-int timesync_refresh = 120; 
+int timesync = 0;
+int timesync_refresh = 120;
 
 // *************************************
 
-//#define USE_SERIAL  SerialUSB //Serial for boards whith USB serial port
+// #define USE_SERIAL  SerialUSB // Serial for boards whith USB serial port
 #define USE_SERIAL  Serial
 
 //***********************************
@@ -206,28 +205,28 @@ bool dallaspresent ();
 
 
 ////////////////////////////////////
-///     AP MODE 
+///     AP MODE
 /////////////////////////////////
 
 String routeur="PV-ROUTER";
-bool AP = false; 
+bool AP = false;
 bool discovery_temp;
 
 
-OneWire  ds(ONE_WIRE_BUS);  //  (a 4.7K resistor is necessary - 5.7K work with 3.3 ans 5V power)
+OneWire ds(ONE_WIRE_BUS);   //  (a 4.7K resistor is necessary - 5.7K work with 3.3 ans 5V power)
 DallasTemperature sensors(&ds);
 
-  
-  byte present = 0;
-  
-  byte data[12]; //NOSONAR
-  float previous_celsius[MAX_DALLAS] = {0.00}; // NOSONAR
-  //byte security = 0;
-  int refresh = 60;
-  int refreshcount = 0; 
+
+byte present = 0;
+
+byte data[12];   // NOSONAR
+float previous_celsius[MAX_DALLAS] = {0.00};   // NOSONAR
+// byte security = 0;
+int refresh = 60;
+int refreshcount = 0;
 int deviceCount = 0;
 int devicealerte=0;
-DeviceAddress addr[MAX_DALLAS];  // array of (up to) MAX_DALLAS temperature sensors NOSONAR
+DeviceAddress addr[MAX_DALLAS];   // array of (up to) MAX_DALLAS temperature sensors NOSONAR
 String devAddrNames[MAX_DALLAS];  // array of (up to) MAX_DALLAS temperature sensors NOSONAR
 /***************************
  * End Settings
@@ -237,102 +236,100 @@ String devAddrNames[MAX_DALLAS];  // array of (up to) MAX_DALLAS temperature sen
 //************* Gestion de la configuration
 //***********************************
 
-Config config; 
-Mqtt mqtt_config; 
+Config config;
+Mqtt mqtt_config;
 System sysvar;
-Programme programme; 
+Programme programme;
 Programme programme_relay1;
 Programme programme_relay2;
 
-String getmqtt(); 
+String getmqtt();
 void savemqtt(const char *filename, const Mqtt &mqtt_config); // NOSONAR
-bool pingIP(IPAddress ip) ;
+bool pingIP(IPAddress ip);
 String stringBool(bool mybool);
 String getServermode(String Servermode);
 String switchstate(int state);
 void tests ();
 
+/// @brief  declaration des logs
+Logs logging;/// declare logs
 
-/// @brief  declaration des logs 
-Logs logging;/// declare logs 
-
-int childsend = 0; 
+int childsend = 0;
 
 
 /***************************
  * init Dimmer
  **************************/
-#ifdef ROBOTDYN  
-    dimmerLamp dimmer(outputPin, zerocross); //initialise port for dimmer for ESP8266, ESP32, Arduino due boards
-  
+#ifdef ROBOTDYN
+dimmerLamp dimmer(outputPin, zerocross);         // initialise port for dimmer for ESP8266, ESP32, Arduino due boards
+
   #ifdef outputPin2
-    dimmerLamp dimmer2(outputPin2, zerocross); //initialise port for dimmer2 for ESP8266, ESP32, Arduino due boards
+dimmerLamp dimmer2(outputPin2, zerocross);       // initialise port for dimmer2 for ESP8266, ESP32, Arduino due boards
   #endif
 
   #ifdef outputPin3
-    dimmerLamp dimmer3(outputPin3, zerocross); //initialise port for dimmer3 for ESP8266, ESP32, Arduino due boards
+dimmerLamp dimmer3(outputPin3, zerocross);       // initialise port for dimmer3 for ESP8266, ESP32, Arduino due boards
   #endif
 #endif
 
-  //// test JOTTA non random
+//// test JOTTA non random
   #ifdef SSR_ZC
   #include <Ticker.h>
-  Ticker timer;
-  SSR_BURST ssr_burst;
+Ticker timer;
+SSR_BURST ssr_burst;
   #endif
 
-gestion_puissance unified_dimmer; 
+gestion_puissance unified_dimmer;
 
-    //***********************************
-    //************* function web 
-    //***********************************
+//***********************************
+//************* function web
+//***********************************
 
 unsigned long Timer_Cooler;
 
-IPAddress _ip,_gw,_sn,gatewayIP  ; // NOSONAR
+IPAddress _ip,_gw,_sn,gatewayIP;   // NOSONAR
 
 
-    //***********************************
-    //************* Setup 
-    //***********************************
+//***********************************
+//************* Setup
+//***********************************
 
 void setup() {
   Serial.begin(115200);
 
-  /// reset du bus one Wire
-  // ds.reset(); 
-  /// initialisation des dallas 
+  // reset du bus one Wire
+  // ds.reset();
+  // initialisation des dallas
   sensors.begin();
 
   #ifdef ESP32ETH
-    ETH.begin(ETH_ADDR, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_TYPE, ETH_CLK_MODE);
+  ETH.begin(ETH_ADDR, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_TYPE, ETH_CLK_MODE);
   #endif
   logging.Set_log_init("197}11}1");
 
-  /// Correction issue full power at start
-  pinMode(outputPin, OUTPUT); 
+  // Correction issue full power at start
+  pinMode(outputPin, OUTPUT);
   pinMode(zerocross, INPUT);
-  #ifndef ESP32ETH 
+  #ifndef ESP32ETH
     #ifndef ESP32
-      pinMode(D1, OUTPUT);
-      digitalWrite(D1, 0);
+  pinMode(D1, OUTPUT);
+  digitalWrite(D1, 0);
     #endif
   #endif
   #ifdef outputPin2
-    pinMode(outputPin2, OUTPUT); 
+  pinMode(outputPin2, OUTPUT);
   #endif
   #ifdef outputPin3
-    pinMode(outputPin3, OUTPUT); 
+  pinMode(outputPin3, OUTPUT);
   #endif
 
-  #ifdef POWERSUPPLY2022  
+  #ifdef POWERSUPPLY2022
   pinMode(GND_PIN, OUTPUT);  /// board bug
-  digitalWrite(GND_PIN, 0);  /// board bug with pin 16 
+  digitalWrite(GND_PIN, 0);  /// board bug with pin 16
 
-  pinMode(POS_PIN, OUTPUT); 
+  pinMode(POS_PIN, OUTPUT);
   digitalWrite(POS_PIN, 1);
   #endif
-
 
   #if defined(ESP32) || defined(ESP32ETH)
   esp_reset_reason_t reset_reason = esp_reset_reason();
@@ -347,86 +344,87 @@ void setup() {
   #endif
 
   #ifdef RELAY1 // permet de rajouter les relais en ne modifiant que config.h, et pas seulement en STANDALONE
-    pinMode(RELAY1, OUTPUT);
-    digitalWrite(RELAY1, LOW);
+  pinMode(RELAY1, OUTPUT);
+  digitalWrite(RELAY1, LOW);
   #endif
   #ifdef RELAY2 // permet de rajouter les relais en ne modifiant que config.h
-    pinMode(RELAY2, OUTPUT);
-    digitalWrite(RELAY2, LOW);
+  pinMode(RELAY2, OUTPUT);
+  digitalWrite(RELAY2, LOW);
   #endif
 
   // cooler init
-  pinMode(COOLER, OUTPUT); 
+  pinMode(COOLER, OUTPUT);
   digitalWrite(COOLER, LOW);
 
   logging.Set_log_init("-- " + String(VERSION) + " --\r\n");
 
-  //démarrage file system
+  // démarrage file system
   LittleFS.begin();
-  // correction d'erreur de chargement de FS 
+  // correction d'erreur de chargement de FS
   delay(1000);
   Serial.println("Demarrage file System");
-  logging.Set_log_init(Start_filesystem); 
+  logging.Set_log_init(Start_filesystem);
   test_fs_version();
 #ifdef ROBOTDYN
   // configuration dimmer
     #ifdef outputPin
-      dimmer.begin(NORMAL_MODE, OFF); //dimmer initialisation: name.begin(MODE, STATE) 
+  dimmer.begin(NORMAL_MODE, OFF);     // dimmer initialisation: name.begin(MODE, STATE)
     #endif
-    #ifdef outputPin2 
-    //  dimmer2.begin(NORMAL_MODE, ON); //dimmer2 initialisation: name.begin(MODE, STATE)  // la déclaration est en fait globale pas besoin de redéclarer et pose pb sur ESP32
+    #ifdef outputPin2
+  // la déclaration est en fait globale pas besoin de redéclarer et pose pb sur ESP32
+  // dimmer2.begin(NORMAL_MODE, ON); // dimmer2 initialisation: name.begin(MODE, STATE)
     #endif
     #ifdef outputPin3
-    //  dimmer3.begin(NORMAL_MODE, ON); //dimmer3 initialisation: name.begin(MODE, STATE) 
+  // dimmer3.begin(NORMAL_MODE, ON); // dimmer3 initialisation: name.begin(MODE, STATE)
     #endif
 
-  #ifdef POWERSUPPLY2022  
+  #ifdef POWERSUPPLY2022
   /// correct bug board
   dimmer.setState(ON);
-  
-  pinMode(GND_PIN, OUTPUT);  /// board bug
-  digitalWrite(GND_PIN, 0);  /// board bug with pin 16 
 
-  pinMode(POS_PIN, OUTPUT); 
+  pinMode(GND_PIN, OUTPUT);  /// board bug
+  digitalWrite(GND_PIN, 0);  /// board bug with pin 16
+
+  pinMode(POS_PIN, OUTPUT);
   digitalWrite(POS_PIN, 1);
   #endif
 #endif
 
 
-  /// init de sécurité     
+  /// init de sécurité
   #ifdef ROBOTDYN
-    dimmer.setState(OFF); 
+  dimmer.setState(OFF);
   #endif
   #ifdef outputPin2
-    dimmer2.setState(OFF);  
+  dimmer2.setState(OFF);
   #endif
   #ifdef outputPin3
-    dimmer3.setState(OFF);  
+  dimmer3.setState(OFF);
   #endif
-    
+
   USE_SERIAL.println("Dimmer Program is starting...");
 
-      //***********************************
-    //************* Setup -  récupération du fichier de configuration
-    //***********************************
+  //***********************************
+  //************* Setup -  récupération du fichier de configuration
+  //***********************************
   #if !defined(ESP32) && !defined(ESP32ETH)
-    ESP.getResetReason();
+  ESP.getResetReason();
   #endif
   // Should load default config if run for the first time
   Serial.println(F("Loading configuration..."));
-  logging.Set_log_init(Load_configuration); 
+  logging.Set_log_init(Load_configuration);
   logging.Set_log_init(config.loadConfiguration()); // charge la configuration
 
-  // Load configuration file mqtt 
+  // Load configuration file mqtt
   Serial.println(F("Loading mqtt_conf configuration..."));
-  logging.Set_log_init(Load_configuration_MQTT); 
-  logging.Set_log_init(mqtt_config.loadmqtt());  /// charge la configuration mqtt
+  logging.Set_log_init(Load_configuration_MQTT);
+  logging.Set_log_init(mqtt_config.loadmqtt());  // charge la configuration mqtt
 
-  /// chargement des conf de wifi
+  // chargement des conf de wifi
   Serial.println(F("Loading wifi configuration..."));
   loadwifiIP(wifi_conf, wifi_config_fixe);
- 
-  /// chargement des conf de minuteries
+
+  // chargement des conf de minuteries
   Serial.println(F("Loading minuterie \r\n"));
   programme.set_name("/dimmer");
   programme.loadProgramme();
@@ -441,108 +439,110 @@ void setup() {
   programme_relay2.loadProgramme();
   programme_relay2.saveProgramme();
 #endif
-    //***********************************
-    //************* Setup - Connexion Wifi
-    //***********************************
+  //***********************************
+  //************* Setup - Connexion Wifi
+  //***********************************
   Serial.print("start Wifiautoconnect");
-  logging.Set_log_init(Start_Wifiautoconnect); 
+  logging.Set_log_init(Start_Wifiautoconnect);
 
-    //WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-    //wifi_set_phy_mode(PHY_MODE_11N);
-  
+  // WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+  // wifi_set_phy_mode(PHY_MODE_11N);
 
 
-   // préparation  configuration IP fixe 
 
-    AsyncWiFiManagerParameter custom_IP_Address("server", "IP", wifi_config_fixe.static_ip, 16);
-    wifiManager.addParameter(&custom_IP_Address);
-    AsyncWiFiManagerParameter custom_IP_mask("mask", "mask", wifi_config_fixe.static_sn, 16);
-    wifiManager.addParameter(&custom_IP_mask);
-    AsyncWiFiManagerParameter custom_IP_gateway("gateway", "gateway", wifi_config_fixe.static_gw, 16);
-    wifiManager.addParameter(&custom_IP_gateway);
+  // préparation  configuration IP fixe
 
-    _ip.fromString(wifi_config_fixe.static_ip);
-    _sn.fromString(wifi_config_fixe.static_sn);
-    _gw.fromString(wifi_config_fixe.static_gw);
+  AsyncWiFiManagerParameter custom_IP_Address("server", "IP", wifi_config_fixe.static_ip, 16);
+  wifiManager.addParameter(&custom_IP_Address);
+  AsyncWiFiManagerParameter custom_IP_mask("mask", "mask", wifi_config_fixe.static_sn, 16);
+  wifiManager.addParameter(&custom_IP_mask);
+  AsyncWiFiManagerParameter custom_IP_gateway("gateway", "gateway", wifi_config_fixe.static_gw, 16);
+  wifiManager.addParameter(&custom_IP_gateway);
 
-    if ( !strcmp(wifi_config_fixe.static_ip, "") == 0) {
-          //set static ip
-            
-          wifiManager.setSTAStaticIPConfig(_ip, _gw, _sn);
-          Serial.print(String(wifi_config_fixe.static_ip));
-    }
+  _ip.fromString(wifi_config_fixe.static_ip);
+  _sn.fromString(wifi_config_fixe.static_sn);
+  _gw.fromString(wifi_config_fixe.static_gw);
 
-    WiFi.setHostname(config.say_my_name); /// doit être placé avant la connexion sinon sous ESP32, l'hostname n'est pas pris en compte
-    wifiManager.autoConnect(config.say_my_name);
-    // Afficher le nom : 
-    Serial.println("say_my_name: " + String(config.say_my_name));
-    DEBUG_PRINTLN("end Wifiautoconnect");
-    wifiManager.setSaveConfigCallback(saveConfigCallback);
-    wifiManager.setConfigPortalTimeout(600);
- 
+  if ( !strcmp(wifi_config_fixe.static_ip, "") == 0) {
+    // set static ip
 
-   strcpy(wifi_config_fixe.static_ip, custom_IP_Address.getValue());
-   strcpy(wifi_config_fixe.static_sn, custom_IP_mask.getValue());
-   strcpy(wifi_config_fixe.static_gw, custom_IP_gateway.getValue());
+    wifiManager.setSTAStaticIPConfig(_ip, _gw, _sn);
+    Serial.print(String(wifi_config_fixe.static_ip));
+  }
 
-    DEBUG_PRINTLN("static adress: " + String(wifi_config_fixe.static_ip) + " mask: " + String(wifi_config_fixe.static_sn) + " GW: " + String(wifi_config_fixe.static_gw));
+  // doit être placé avant la connexion sinon sous ESP32, l'hostname n'est pas pris en compte
+  WiFi.setHostname(config.say_my_name);
+  wifiManager.autoConnect(config.say_my_name);
+  // Afficher le nom :
+  Serial.println("say_my_name: " + String(config.say_my_name));
+  DEBUG_PRINTLN("end Wifiautoconnect");
+  wifiManager.setSaveConfigCallback(saveConfigCallback);
+  wifiManager.setConfigPortalTimeout(600);
 
-    //savewifiIP(wifi_conf, wifi_config_fixe); // NOSONAR je doute que ça soit utilisé vu que c'est en autoconnect, seul le chargement est necessaire
-  
+
+  strcpy(wifi_config_fixe.static_ip, custom_IP_Address.getValue());
+  strcpy(wifi_config_fixe.static_sn, custom_IP_mask.getValue());
+  strcpy(wifi_config_fixe.static_gw, custom_IP_gateway.getValue());
+
+  DEBUG_PRINTLN("static adress: " + String(wifi_config_fixe.static_ip) + " mask: " + String(
+                  wifi_config_fixe.static_sn) + " GW: " + String(wifi_config_fixe.static_gw));
+
+  // savewifiIP(wifi_conf, wifi_config_fixe); // NOSONAR je doute que ça soit utilisé vu que c'est en autoconnect, seul le chargement est necessaire
+
   // Wait for connection
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
   }
 
-    
-   // WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-    //wifi_set_phy_mode(PHY_MODE_11N);
-    WiFi.setAutoReconnect(true);
-   // WiFi.setOutputPower(20);
 
-   /// restart si la configuration OP static est différente ip affectée suite changement ip Autoconf
+  // WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+  // wifi_set_phy_mode(PHY_MODE_11N);
+  WiFi.setAutoReconnect(true);
+  // WiFi.setOutputPower(20);
+
+  /// restart si la configuration OP static est différente ip affectée suite changement ip Autoconf
   if ( !strcmp(wifi_config_fixe.static_ip, "" ) == 0 )  {
-         char IP[] = "xxx.xxx.xxx.xxx";  // NOSONAR
-         IPAddress ip = WiFi.localIP();
-         ip.toString().toCharArray(IP, 16);
-        if (!strcmp(wifi_config_fixe.static_ip,IP) == 0) {
+    char IP[] = "xxx.xxx.xxx.xxx";       // NOSONAR
+    IPAddress ip = WiFi.localIP();
+    ip.toString().toCharArray(IP, 16);
+    if (!strcmp(wifi_config_fixe.static_ip,IP) == 0) {
       DEBUG_PRINTLN(wifi_config_fixe.static_ip);
       Serial.println(WiFi.localIP());
 
       Serial.print("Application de la nouvelle configuration Ip   ");
       config.restart = true;
-      }
+    }
   }
-  //Si connexion affichage info dans console
+  // Si connexion affichage info dans console
   Serial.println("");
   DEBUG_PRINTLN("Connection ok sur le reseau :  ");
- 
+
   Serial.print("IP address: ");
 
-  Serial.println(WiFi.localIP()); 
+  Serial.println(WiFi.localIP());
   gatewayIP = WiFi.gatewayIP();
   Serial.println(gatewayIP);
-  
+
 
   #if !defined(ESP32) && !defined(ESP32ETH)
-    Serial.println(ESP.getResetReason());
+  Serial.println(ESP.getResetReason());
   #endif
-  //// AP MODE 
+  //// AP MODE
   if ( routeur.compareTo(WiFi.SSID().substring(0,9)) == 0 ) {
-      AP = true; 
+    AP = true;
   }
 
-    // Initialize mDNS
-    //config.say_my_name)
-  if (!MDNS.begin(config.say_my_name)) {   
+  // Initialize mDNS
+  // config.say_my_name)
+  if (!MDNS.begin(config.say_my_name)) {
     Serial.println("Error setting up MDNS responder!");
     while(1) {
       delay(1000);
     }
   }
   Serial.println("mDNS responder started");
-  //MDNS.addService("http", "tcp", 80);
+  // MDNS.addService("http", "tcp", 80);
   MDNS.addService("http", "tcp", 1308);
 
   logging.Set_log_init(mDNS_Responder_Started);
@@ -550,60 +550,59 @@ void setup() {
 
 
 
-    //***********************************
-    //************* Setup - OTA 
-    //***********************************
-    ElegantOTA.begin(&server);    // Start ElegantOTA
-   
-    //***********************************
-    //************* Setup - Web pages
-    //***********************************
+  //***********************************
+  //************* Setup - OTA
+  //***********************************
+  ElegantOTA.begin(&server);      // Start ElegantOTA
+
+  //***********************************
+  //************* Setup - Web pages
+  //***********************************
 
 
-  //chargement des url des pages
+  // chargement des url des pages
   call_pages();
 
-    //***********************************
-    //************* Setup -  demarrage du webserver et affichage de l'oled
-    //***********************************
+  //***********************************
+  //************* Setup -  demarrage du webserver et affichage de l'oled
+  //***********************************
   Serial.println("start server");
-  server.begin(); 
-    
+  server.begin();
 
-  //// récupération des dallas .  
+
+  //// récupération des dallas .
   Serial.println("start 18b20");
-  
+
   delay(1000);
   deviceCount = sensors.getDeviceCount();
-  
-  if (deviceCount == 0 ) { //si toujours pas trouvé 
-    sensors.begin(); //réinit du bus one wire
+
+  if (deviceCount == 0 ) { // si toujours pas trouvé
+    sensors.begin(); // réinit du bus one wire
     delay(1500);
     deviceCount = sensors.getDeviceCount();
   }
 
-  logging.Set_log_init(String(deviceCount)); 
+  logging.Set_log_init(String(deviceCount));
   logging.Set_log_init(DALLAS_detected);
-    
+
   /// recherche d'une sonde dallas
   dallaspresent();
 
   devices_init(); // initialisation des devices HA
- 
-  /// MQTT 
+
+  /// MQTT
   if (!AP && mqtt_config.mqtt) {
     Serial.println("Connection MQTT" );
-    logging.Set_log_init(Attempting_MQTT_connexion); 
-    
-    /// Configuration et connexion MQTT 
+    logging.Set_log_init(Attempting_MQTT_connexion);
+
+    /// Configuration et connexion MQTT
     async_mqtt_init();
 
-    delay(1000);  
+    delay(1000);
     connectToMqtt();
-    delay(1000);  
+    delay(1000);
     /// pour remonter un 0 sur le MQTT
-          if (config.HA || config.JEEDOM) {
-
+    if (config.HA || config.JEEDOM) {
       device_dimmer.send(String(sysvar.puissance));
       device_dimmer_send_power.send(String(sysvar.puissance));
       device_dimmer_power.send(String(sysvar.puissance* config.charge/100));
@@ -616,69 +615,67 @@ void setup() {
       device_dimmer_child_mode.send(String(config.mode));
       device_dimmer_on_off.send(String(config.dimmer_on_off));
 
-
-
       #ifdef RELAY1
-        int relaystate = digitalRead(RELAY1); 
-        device_relay1.send(String(relaystate));
+      int relaystate = digitalRead(RELAY1);
+      device_relay1.send(String(relaystate));
       #endif
       #ifdef RELAY2
-        relaystate = digitalRead(RELAY2); 
-        device_relay2.send(String(relaystate));
+      relaystate = digitalRead(RELAY2);
+      device_relay2.send(String(relaystate));
       #endif
       HA_discover();
     }
   }
-  
- 
+
+
   #ifdef  SSR
     #ifdef OLDSSR
-      analogWriteFreq(GRIDFREQ) ; 
-      analogWriteRange(100);
-      analogWrite(JOTTA, 0);
+  analogWriteFreq(GRIDFREQ);
+  analogWriteRange(100);
+  analogWrite(JOTTA, 0);
     #elif  defined(SSR_ZC)
-      pinMode(JOTTA, OUTPUT);
-      unified_dimmer.set_power(0);
-      timer.attach_ms(10, SSR_run); // Attachez la fonction task() au temporisateur pour qu'elle s'exécute toutes les 1000 ms
+  pinMode(JOTTA, OUTPUT);
+  unified_dimmer.set_power(0);
+  timer.attach_ms(10, SSR_run);     // Attachez la fonction task() au temporisateur pour qu'elle s'exécute toutes les 1000 ms
     #else
-      init_jotta(); 
-      timer_init();
+  init_jotta();
+  timer_init();
     #endif
   #endif
 
 
-/// init du NTP
-ntpinit(); 
+  /// init du NTP
+  ntpinit();
 
-/// init des tasks
-runner.init();
-runner.addTask(Task_dallas);    
-Task_dallas.enable();
+  /// init des tasks
+  runner.init();
+  runner.addTask(Task_dallas);
+  Task_dallas.enable();
 
-runner.addTask(Task_Cooler);
-Task_Cooler.enable();
+  runner.addTask(Task_Cooler);
+  Task_Cooler.enable();
 
-runner.addTask(Task_GET_POWER);
-Task_GET_POWER.enable();
+  runner.addTask(Task_GET_POWER);
+  Task_GET_POWER.enable();
 
-runner.addTask(Task_ping);
-Task_ping.enable();
+  runner.addTask(Task_ping);
+  Task_ping.enable();
 
-DEBUG_PRINTLN(ESP.getFreeHeap());
+  DEBUG_PRINTLN(ESP.getFreeHeap());
 
-/// affichage de l'heure  GMT +1 dans la log
-logging.Set_log_init(End_Start);
-logging.Set_log_init("",true);
-logging.Set_log_init("\r\n");
+  /// affichage de l'heure  GMT +1 dans la log
+  logging.Set_log_init(End_Start);
+  logging.Set_log_init("",true);
+  logging.Set_log_init("\r\n");
 
-delay(1000);
+  delay(1000);
 }
 
 
 bool alerte=false;
 
 /////////////////////
-/// LOOP 
+/// LOOP
 /////////////////////
 void loop() {
   client.loop();
@@ -689,10 +686,10 @@ void loop() {
   #endif
 
   /// connexion MQTT dans les cas de conf mqtt et perte de connexion
-   if (!client.connected() ) { 
+  if (!client.connected() ) {
     mqttConnected = false;
-   }
-      if (!mqttConnected && !AP && mqtt_config.mqtt) {
+  }
+  if (!mqttConnected && !AP && mqtt_config.mqtt) {
     connect_and_subscribe();
   }
 
@@ -705,97 +702,93 @@ void loop() {
   if (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print("NO WIFI - Restarting Dimmer");
-
     config.restart = true;
   }
 
-  ///////////////// gestion des activité minuteur 
- //// Dimmer 
-  if (programme.run) { 
-      //  minuteur en cours
-      if (programme.stop_progr()) { 
-            // Robotdyn dimmer
+  ///////////////// gestion des activité minuteur
+  //// Dimmer
+  if (programme.run) {
+    //  minuteur en cours
+    if (programme.stop_progr()) {
+      // Robotdyn dimmer
       logging.Set_log_init(Stop_minuteur,true);
-            unified_dimmer.set_power(0); // necessaire pour les autres modes
-            unified_dimmer.dimmer_off();
+      unified_dimmer.set_power(0);       // necessaire pour les autres modes
+      unified_dimmer.dimmer_off();
 
-        DEBUG_PRINTLN("programme.run");
-        sysvar.puissance=0;
-        Serial.print(Stop_minuteur);
-        Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) ); // remonté MQTT de la commande réelle
-        if (config.HA) {
-          int instant_power = unified_dimmer.get_power();
-          device_dimmer_on_off.send(String(config.dimmer_on_off));
-          device_dimmer.send(String(instant_power));
-          device_dimmer_send_power.send(String(instant_power));
-          device_dimmer_power.send(String(instant_power * config.charge/100)); 
-          device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));
-        } 
-        // réinint de la sécurité température 
-        sysvar.security = 0 ;
-
-      } 
-  } 
-  else { 
+      DEBUG_PRINTLN("programme.run");
+      sysvar.puissance=0;
+      Serial.print(Stop_minuteur);
+      Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );   // remonté MQTT de la commande réelle
+      if (config.HA) {
+        int instant_power = unified_dimmer.get_power();
+        device_dimmer_on_off.send(String(config.dimmer_on_off));
+        device_dimmer.send(String(instant_power));
+        device_dimmer_send_power.send(String(instant_power));
+        device_dimmer_power.send(String(instant_power * config.charge/100));
+        device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));
+      }
+      // réinint de la sécurité température
+      sysvar.security = 0;
+    }
+  }
+  else {
     // minuteur à l'arret
-    if (programme.start_progr()){ 
-      // definition de la puissance à appliquer 
+    if (programme.start_progr()) {
+      // definition de la puissance à appliquer
       if ( programme.puissance > config.maxpow ) {     sysvar.puissance=config.maxpow; }
-      else { sysvar.puissance = programme.puissance; }  
-       
-          //// robotdyn dimmer
-              logging.Set_log_init(Start_minuteur,true);
+      else { sysvar.puissance = programme.puissance; }
 
-              unified_dimmer.set_power(sysvar.puissance); 
-              delay (50);
+      //// robotdyn dimmer
+      logging.Set_log_init(Start_minuteur,true);
+
+      unified_dimmer.set_power(sysvar.puissance);
+      delay (50);
 
       Serial.print(Start_minuteur);
       Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) ); // remonté MQTT de la commande réelle
       if (config.HA) {
         int instant_power = unified_dimmer.get_power();
-      device_dimmer_on_off.send(String(config.dimmer_on_off));
+        device_dimmer_on_off.send(String(config.dimmer_on_off));
         device_dimmer.send(String(instant_power));
-      device_dimmer_send_power.send(String(instant_power));
-        device_dimmer_power.send(String(instant_power * config.charge/100)); 
+        device_dimmer_send_power.send(String(instant_power));
+        device_dimmer_power.send(String(instant_power * config.charge/100));
         device_dimmer_total_power.send(String(sysvar.puissance_cumul + (sysvar.puissance * config.charge/100)));
-      } 
-
+      }
     }
   }
 
 
 #ifdef RELAY1
- //// relay 1 
- if (programme_relay1.run) { 
-      if (programme_relay1.stop_progr()) { 
-        logging.Set_log_init(Stop_minuteur_relay1,true);
-        digitalWrite(RELAY1 , LOW);
-        device_relay1.send(String(0));
+  //// relay 1
+  if (programme_relay1.run) {
+    if (programme_relay1.stop_progr()) {
+      logging.Set_log_init(Stop_minuteur_relay1,true);
+      digitalWrite(RELAY1, LOW);
+      device_relay1.send(String(0));
+    }
+  }
+  else {
+    if (programme_relay1.start_progr()) {
+      logging.Set_log_init(Start_minuteur_relay1,true);
+      digitalWrite(RELAY1, HIGH);
+      device_relay1.send(String(1));
+    }
+  }
 
-      }
- }
- else {
-      if (programme_relay1.start_progr()){ 
-        logging.Set_log_init(Start_minuteur_relay1,true);
-        digitalWrite(RELAY1 , HIGH);
-        device_relay1.send(String(1));
-      }
- }
-
- if (programme_relay2.run) { 
-      if (programme_relay2.stop_progr()) { 
-        logging.Set_log_init(Stop_minuteur_relay2,true);
-        digitalWrite(RELAY2 , LOW);
-        device_relay2.send(String(0));
-      }
- }
- else {
-      if (programme_relay2.start_progr()){ 
-        logging.Set_log_init(Start_minuteur_relay2,true);
-        digitalWrite(RELAY2 , HIGH);
-        device_relay2.send(String(1));
-      }
- }
+  if (programme_relay2.run) {
+    if (programme_relay2.stop_progr()) {
+      logging.Set_log_init(Stop_minuteur_relay2,true);
+      digitalWrite(RELAY2, LOW);
+      device_relay2.send(String(0));
+    }
+  }
+  else {
+    if (programme_relay2.start_progr()) {
+      logging.Set_log_init(Start_minuteur_relay2,true);
+      digitalWrite(RELAY2, HIGH);
+      device_relay2.send(String(1));
+    }
+  }
 #endif
 
   ///////////////// commande de restart /////////
@@ -806,37 +799,41 @@ void loop() {
   }
 
   //// si la sécurité température est active on coupe le dimmer
-  if ( sysvar.celsius[sysvar.dallas_maitre] > ( config.maxtemp + 2) && (!alerte) ) { 
+  if ( sysvar.celsius[sysvar.dallas_maitre] > ( config.maxtemp + 2) && (!alerte) ) {
+    /// send alert to MQTT
+    Mqtt_send_DOMOTICZ(
+      String(config.IDXAlarme),
+      String("Alert Temp :" + String(sysvar.celsius[sysvar.dallas_maitre]) ),
+      "Alerte"
+      );
 
-    Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String("Alert Temp :" + String(sysvar.celsius[sysvar.dallas_maitre]) ),"Alerte");  ///send alert to MQTT
+    alerte=true;
+    unified_dimmer.dimmer_off();
+  }
 
-            alerte=true;
-            unified_dimmer.dimmer_off();
-          }
-
-  if ( sysvar.security == 1 ) { 
-      if (!alerte){
-        Serial.println("Alert Temp");
+  if ( sysvar.security == 1 ) {
+    if (!alerte) {
+      Serial.println("Alert Temp");
       logging.Set_log_init(Alert_Temp,true);
-      
-        if (!AP && mqtt_config.mqtt ){
-              Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String("Ballon chaud " ),"Alerte");  ///send alert to MQTT
-              device_dimmer_alarm_temp.send("Hot water");
-        }
-        alerte=true;
-        
+
+      if (!AP && mqtt_config.mqtt ) {
+        Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String("Ballon chaud " ),"Alerte");        /// send alert to MQTT
+        device_dimmer_alarm_temp.send("Hot water");
       }
+      alerte=true;
+    }
     //// Trigger de sécurité température
-      if ( sysvar.celsius[sysvar.dallas_maitre] <= (config.maxtemp - (config.maxtemp*config.trigger/100)) ) {  
-        sysvar.security = 0 ;
-                if (!AP && mqtt_config.mqtt && config.HA) { device_dimmer_alarm_temp.send(stringBool(sysvar.security)); 
-                 Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String("RAS" ),"Alerte");
-                }
-        sysvar.change = 1 ;
+    if ( sysvar.celsius[sysvar.dallas_maitre] <= (config.maxtemp - (config.maxtemp*config.trigger/100)) ) {
+      sysvar.security = 0;
+      if (!AP && mqtt_config.mqtt && config.HA) {
+        device_dimmer_alarm_temp.send(stringBool(sysvar.security));
+        Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String("RAS" ),"Alerte");
       }
-      else {
-        unified_dimmer.dimmer_off();
-      }
+      sysvar.change = 1;
+    }
+    else {
+      unified_dimmer.dimmer_off();
+    }
   }
   else {
     alerte=false;
@@ -846,297 +843,291 @@ void loop() {
 
   if ( sysvar.change == 1  && programme.run == false ) {   /// si changement et pas de minuteur en cours
 
-    if (config.dimmer_on_off == 0){
-              unified_dimmer.dimmer_off();
+    if (config.dimmer_on_off == 0) {
+      unified_dimmer.dimmer_off();
     }
-    
-    /// si on dépasse la puissance mini demandée 
+
+    /// si on dépasse la puissance mini demandée
     DEBUG_PRINTLN(("%d------------------",__LINE__));
     DEBUG_PRINTLN(sysvar.puissance);
 
-   if (sysvar.puissance_cumul != 0) {
+    if (sysvar.puissance_cumul != 0) {
       if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 && strcmp(config.mode,"off") == 0 ) {
-        child_communication(0,false); 
+        child_communication(0,false);
         // Du coup je force sysvar.puissance_cumul à 0 puisque Task_GET_POWER ne renverra plus rien désormais
         // ça évitera de rentrer dans cette boucle à l'infini en bombardant le dimmer d'ordres à 0 pour rien
         sysvar.puissance_cumul = 0;
-
       }
-    }    
-    if (sysvar.puissance > config.minpow && sysvar.puissance != 0 && sysvar.security == 0) 
+    }
+    if (sysvar.puissance > config.minpow && sysvar.puissance != 0 && sysvar.security == 0)
     {
-         DEBUG_PRINTLN(("%d------------------",__LINE__));
-        /// si au dessus de la consigne max configurée alors config.maxpow. 
-        if ( sysvar.puissance > config.maxpow ) //|| sysvar.puissance_cumul > sysvar.puissancemax )  
-        { 
-          if (config.dimmer_on_off == 1){
-            unified_dimmer.set_power(config.maxpow);
-            DEBUG_PRINTLN(("%d------------------",__LINE__));
-
+      DEBUG_PRINTLN(("%d------------------",__LINE__));
+      /// si au dessus de la consigne max configurée alors config.maxpow.
+      if ( sysvar.puissance > config.maxpow )   // || sysvar.puissance_cumul > sysvar.puissancemax )
+      {
+        if (config.dimmer_on_off == 1) {
+          unified_dimmer.set_power(config.maxpow);
+          DEBUG_PRINTLN(("%d------------------",__LINE__));
+        }
+        /// si on a une carte fille et qu'elle n'est pas configurée sur off, on envoie la commande
+        if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 && strcmp(config.mode,"off") != 0 ) {
+          if ( strcmp(config.mode,"delester") == 0 ) {
+            child_communication(int((sysvar.puissance-config.maxpow)),true );      // si mode délest, envoi du surplus
           }
-          /// si on a une carte fille et qu'elle n'est pas configurée sur off, on envoie la commande 
-          if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 && strcmp(config.mode,"off") != 0 ) {
-              
-              if ( strcmp(config.mode,"delester") == 0 ) { 
-                child_communication(int((sysvar.puissance-config.maxpow)),true );  // si mode délest, envoi du surplus
-              }
-              if ( strcmp(config.mode,"equal") == 0) { 
-                child_communication(sysvar.puissance,true);   //si mode equal envoie de la commande vers la carte fille
-}
+          if ( strcmp(config.mode,"equal") == 0) {
+            child_communication(sysvar.puissance,true);       // si mode equal envoie de la commande vers la carte fille
           }
+        }
         DEBUG_PRINTLN(("%d------------------",__LINE__));
         DEBUG_PRINTLN(sysvar.puissance);
-        }
-        /// fonctionnement normal
-        else 
-        { 
-        if (config.dimmer_on_off == 1){
+      }
+      /// fonctionnement normal
+      else
+      {
+        if (config.dimmer_on_off == 1) {
           unified_dimmer.set_power(sysvar.puissance);
         }
 
-          if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 ) {
-            
-            if ( strcmp(config.mode,"equal") == 0) { 
-              child_communication(int(sysvar.puissance),true); 
-            
-            }  //si mode equal envoie de la commande vers la carte fille
-            if ( strcmp(config.mode,"delester") == 0 && sysvar.puissance <= config.maxpow) { 
-              child_communication(0,false); 
-               logging.Set_log_init(Child_at_zero); 
-            }  //si mode délest envoie d'une commande à 0
-
-            if ( strcmp(config.mode,"delester") == 0 && sysvar.puissance > config.maxpow) { // si sysvar.puissance passe subitement au dessus de config.maxpow
-              child_communication(int((sysvar.puissance-config.maxpow)),true );
-              
-            }
-              DEBUG_PRINTLN(("%d  -----------------",__LINE__));
-              DEBUG_PRINTLN(sysvar.puissance);
+        if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 ) {
+          // si mode equal envoie de la commande vers la carte fille
+          if ( strcmp(config.mode,"equal") == 0) {
+            child_communication(int(sysvar.puissance),true);
           }
+          // si mode délest envoie d'une commande à 0
+          if ( strcmp(config.mode,"delester") == 0 && sysvar.puissance <= config.maxpow) {
+            child_communication(0,false);
+            logging.Set_log_init(Child_at_zero);
+          }
+          // si sysvar.puissance passe subitement au dessus de config.maxpow
+          if ( strcmp(config.mode,"delester") == 0 && sysvar.puissance > config.maxpow) {
+            child_communication(int((sysvar.puissance-config.maxpow)),true );
+          }
+          DEBUG_PRINTLN(("%d  -----------------",__LINE__));
+          DEBUG_PRINTLN(sysvar.puissance);
         }
-         DEBUG_PRINTLN(("%d------------------",__LINE__));
-         DEBUG_PRINTLN(sysvar.puissance);
-        
+      }
+      DEBUG_PRINTLN(("%d------------------",__LINE__));
+      DEBUG_PRINTLN(sysvar.puissance);
+
       /// si on est en mode MQTT on remonte les valeurs vers HA et MQTT
-      if (!AP && mqtt_config.mqtt) { 
-        if (config.dimmer_on_off == 0){
+      if (!AP && mqtt_config.mqtt) {
+        if (config.dimmer_on_off == 0) {
           Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );  // remonté MQTT de la commande 0
           device_dimmer.send("0");  // remonté MQTT HA de la commande 0
           device_dimmer_send_power.send("0");
-          device_dimmer_power.send("0"); 
+          device_dimmer_power.send("0");
 
         }
         else if ( sysvar.puissance > config.maxpow ) {
           Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );  // remonté MQTT de la commande max
           if (config.HA) {
-            device_dimmer.send(String(config.maxpow)); 
+            device_dimmer.send(String(config.maxpow));
             /// Modif RV - 20240219
             /// Oubli d'envoie "device_dimmer_power.send" + correction de "device_dimmer_total_power.send"
-            device_dimmer_power.send(String(config.maxpow * config.charge/100)); 
-            device_dimmer_total_power.send(String(sysvar.puissance_cumul + (config.maxpow * config.charge/100))); }  // remonté MQTT HA de la commande max
-
+            device_dimmer_power.send(String(config.maxpow * config.charge/100));
+            device_dimmer_total_power.send(String(sysvar.puissance_cumul + (config.maxpow * config.charge/100)));
+          }                                                                                                          // remonté MQTT HA de la commande max
         }
         else {
           Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100)); // remonté MQTT de la commande réelle
           if (config.HA) {
-              int instant_power = unified_dimmer.get_power();
-              device_dimmer.send(String(instant_power));
-              device_dimmer_power.send(String(instant_power * config.charge/100)); 
-              device_dimmer_total_power.send(String(sysvar.puissance_cumul + (instant_power * config.charge/100)));
-            } // remonté MQTT HA de la commande réelle
+            int instant_power = unified_dimmer.get_power();
+            device_dimmer.send(String(instant_power));
+            device_dimmer_power.send(String(instant_power * config.charge/100));
+            device_dimmer_total_power.send(String(sysvar.puissance_cumul + (instant_power * config.charge/100)));
+          }   // remonté MQTT HA de la commande réelle
         }
       }
     }
-    /// si la sécurité est active on déleste 
+    /// si la sécurité est active on déleste
     else if ( sysvar.puissance != 0 && sysvar.security == 1)
     {
 
       if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0  && strcmp(config.mode,"off") != 0) {
-        if (sysvar.puissance > 200 ) {sysvar.puissance = 200 ;}
+        if (sysvar.puissance > 200 ) {sysvar.puissance = 200;}
 
-        if ( strcmp(config.mode,"delester") == 0 ) { child_communication(int(sysvar.puissance) ,true); childsend = 0 ; } // si mode délest, envoi du surplus
-        if ( strcmp(config.mode,"equal") == 0) { child_communication(sysvar.puissance,true); childsend = 0 ; }  //si mode equal envoie de la commande vers la carte fille
+        // si mode délest, envoi du surplus
+        if ( strcmp(config.mode,"delester") == 0 ) { child_communication(int(sysvar.puissance),true); childsend = 0; }
+        // si mode equal envoie de la commande vers la carte fille
+        if ( strcmp(config.mode,"equal") == 0) { child_communication(sysvar.puissance,true); childsend = 0; }
       }
     }
     //// si la commande est trop faible on coupe tout partout
-    else if ( sysvar.puissance <= config.minpow ){
-        DEBUG_PRINTLN("commande est trop faible");
-        unified_dimmer.set_power(0); // necessaire pour les autres modes
-        unified_dimmer.dimmer_off();
-              /// et sur les sous routeur 
-        if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 ) {
-            if ( strcmp(config.mode,"delester") == 0 ) { child_communication(0,false); } // si mode délest, envoi du surplus
-            if ( strcmp(config.mode,"equal") == 0) { child_communication(0,false); }  //si mode equal envoie de la commande vers la carte fille
-            if ( strcmp(config.mode,"off") != 0) {
-                 if (childsend>2) { 
-                    child_communication(0,false);
-                    childsend++; 
-                }
-            }
-
-            if ( mqtt_config.mqtt ) {
-              Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );
-            }
-            if ( config.HA ) { 
-              device_dimmer.send("0"); 
-              device_dimmer_power.send("0");
-            }
-
+    else if ( sysvar.puissance <= config.minpow ) {
+      DEBUG_PRINTLN("commande est trop faible");
+      unified_dimmer.set_power(0);   // necessaire pour les autres modes
+      unified_dimmer.dimmer_off();
+      /// et sur les sous routeur
+      if ( strcmp(config.child,"") != 0 && strcmp(config.child,"none") != 0 ) {
+        if ( strcmp(config.mode,"delester") == 0 ) { child_communication(0,false); }     // si mode délest, envoi du surplus
+        if ( strcmp(config.mode,"equal") == 0) { child_communication(0,false); }      // si mode equal envoie de la commande vers la carte fille
+        if ( strcmp(config.mode,"off") != 0) {
+          if (childsend>2) {
+            child_communication(0,false);
+            childsend++;
+          }
         }
 
-
-        if (!AP && mqtt_config.Mqtt::mqtt) {
-          int instant_power = unified_dimmer.get_power();
-          Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );  // correction 19/04
-          device_dimmer.send(String(instant_power));
-          device_dimmer_send_power.send(String(instant_power));
-          device_dimmer_power.send(String(instant_power * config.charge/100)); 
-          device_dimmer_total_power.send(String(sysvar.puissance_cumul + (instant_power*config.charge/100) ));
+        if ( mqtt_config.mqtt ) {
+          Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );
         }
+        if ( config.HA ) {
+          device_dimmer.send("0");
+          device_dimmer_power.send("0");
+        }
+      }
 
+      if (!AP && mqtt_config.Mqtt::mqtt) {
+        int instant_power = unified_dimmer.get_power();
+        Mqtt_send_DOMOTICZ(String(config.IDX), String (sysvar.puissance * config.charge/100) );    // correction 19/04
+        device_dimmer.send(String(instant_power));
+        device_dimmer_send_power.send(String(instant_power));
+        device_dimmer_power.send(String(instant_power * config.charge/100));
+        device_dimmer_total_power.send(String(sysvar.puissance_cumul + (instant_power*config.charge/100) ));
+      }
     }
-    
-  sysvar.change = 0; /// déplacé ici à la fin
+
+    sysvar.change = 0; /// déplacé ici à la fin
   }
 
-    //***********************************
-    //************* LOOP - Activation de la sécurité --> doublon partiel avec la fonction sécurité ?  
-    //***********************************
-if ( sysvar.celsius[sysvar.dallas_maitre] >= config.maxtemp && sysvar.security == 0 ) {
-  sysvar.security = 1 ; 
-  unified_dimmer.set_power(0); // necessaire pour les autres modes
-            unified_dimmer.dimmer_off();
-  float temp = sysvar.celsius[sysvar.dallas_maitre] + 0.2; /// pour être sur que la dernière consigne envoyé soit au moins égale au max.temp  
-  Mqtt_send_DOMOTICZ(String(config.IDXTemp), String(temp),"Temperature");  /// remonté MQTT de la température
-  if ( config.HA ) { 
-          device_temp[sysvar.dallas_maitre].send(String(temp)); 
-          device_temp_master.send(String(temp)); 
-          device_dimmer_alarm_temp.send(stringBool(sysvar.security));
-          device_dimmer_power.send(String(0));
-          device_dimmer_total_power.send(String(sysvar.puissance_cumul));
-          }  /// si HA remonté MQTT HA de la température
-}
+  //***********************************
+  //************* LOOP - Activation de la sécurité --> doublon partiel avec la fonction sécurité ?
+  //***********************************
+  if ( sysvar.celsius[sysvar.dallas_maitre] >= config.maxtemp && sysvar.security == 0 ) {
+    sysvar.security = 1;
+    unified_dimmer.set_power(0); // necessaire pour les autres modes
+    unified_dimmer.dimmer_off();
+    /// pour être sur que la dernière consigne envoyé soit au moins égale au max.temp
+    float temp = sysvar.celsius[sysvar.dallas_maitre] + 0.2;
+    Mqtt_send_DOMOTICZ(String(config.IDXTemp), String(temp),"Temperature"); /// remonté MQTT de la température
+    if ( config.HA ) {
+      device_temp[sysvar.dallas_maitre].send(String(temp));
+      device_temp_master.send(String(temp));
+      device_dimmer_alarm_temp.send(stringBool(sysvar.security));
+      device_dimmer_power.send(String(0));
+      device_dimmer_total_power.send(String(sysvar.puissance_cumul));
+    }        /// si HA remonté MQTT HA de la température
+  }
 
-//// protection contre la perte de la sonde dallas
+  //// protection contre la perte de la sonde dallas
   if (strlen(config.SubscribeTEMP) == 0 ) {
     restart_dallas();
   }
-
-
- delay(100);  // 24/01/2023 changement 500 à 100ms pour plus de réactivité
+  delay(100); // 24/01/2023 changement 500 à 100ms pour plus de réactivité
 }
 
 ///////////////
-////fin de loop 
+//// fin de loop
 //////////////
 
-    //***********************************
-    //************* Test de la présence d'une 18b20 
-    //***********************************
+//***********************************
+//************* Test de la présence d'une 18b20
+//***********************************
 
 bool dallaspresent () {
 
-  /// alerte d'une deection de dallas passée non trouvée 
-  if (deviceCount == 0 && ( strcmp("null", config.DALLAS) != 0 || strcmp("none", config.DALLAS) != 0 )){
-    /// remonter l'alerte une fois toute les 10 secondes 
+  /// alerte d'une deection de dallas passée non trouvée
+  if (deviceCount == 0 && ( strcmp("null", config.DALLAS) != 0 || strcmp("none", config.DALLAS) != 0 )) {
+    /// remonter l'alerte une fois toute les 10 secondes
     if (devicealerte == 0) {
       logging.Set_log_init(Alerte_Dallas_not_found);
-      Mqtt_send_DOMOTICZ(String(config.IDXTemp), String("Alerte Dallas non trouvée"),"Alerte");  ///send alert to MQTT
+      Mqtt_send_DOMOTICZ(String(config.IDXTemp), String("Alerte Dallas non trouvée"),"Alerte");  /// send alert to MQTT
       device_dimmer_alarm_temp.send("Alerte Dallas non trouvée");
       logging.Set_alerte_web("Dallas Maitre non trouvée");
       devicealerte++;
     }
     else {
-      devicealerte ++;
+      devicealerte++;
       if (devicealerte > 10) {
         devicealerte = 0;
       }
     }
     return false;
   }
-  
+
   logging.Set_alerte_web("");
 
   //// recherche des adresses des sondes
 
   for (int i = 0; i < deviceCount; i++) {
-    //int attempts = 0;
-    //bool sensorFound = false;
-  /// cas pour les sondes les plus lentes 
- /*   while (!sensorFound) {
-      if (!ds.search(addr[i])) {
-        delay(200); // try again after a short delay
-        attempts++;
-        if (attempts > 5) { // timeout: 5 attempts * 200ms each
-          break;
-        }
-      } else {
-        sensorFound = true;
-      }
-    }
+    // int attempts = 0;
+    // bool sensorFound = false;
+    /// cas pour les sondes les plus lentes
+    /*   while (!sensorFound) {
+         if (!ds.search(addr[i])) {
+           delay(200); // try again after a short delay
+           attempts++;
+           if (attempts > 5) { // timeout: 5 attempts * 200ms each
+             break;
+           }
+         } else {
+           sensorFound = true;
+         }
+       }
 
-    /// si pas de sonde trouvée
-    if (!sensorFound) {
-      logging.Set_log_init("Unable to find temperature sensors address \r\n", true);
-      return false;
-    }*/
+       /// si pas de sonde trouvée
+       if (!sensorFound) {
+         logging.Set_log_init("Unable to find temperature sensors address \r\n", true);
+         return false;
+       }*/
 
-  if (!sensors.getAddress(addr[i], i)) Serial.println("Unable to find address for Device 1");
-  else {
-    sensors.setResolution(addr[i], TEMPERATURE_PRECISION);
+    if (!sensors.getAddress(addr[i], i)) Serial.println("Unable to find address for Device 1");
+    else {
+      sensors.setResolution(addr[i], TEMPERATURE_PRECISION);
     }
   }
 
   for (int a = 0; a < deviceCount; a++) {
     String address = "";
     Serial.print("ROM =");
-      for (uint8_t i = 0; i < 8; i++) {
-        if (addr[a][i] < 0x10) address += "0";
-        address += String(addr[a][i], HEX);
-        Serial.write(' ');
-        Serial.print(addr[a][i], HEX);
-      }
+    for (uint8_t i = 0; i < 8; i++) {
+      if (addr[a][i] < 0x10) address += "0";
+      address += String(addr[a][i], HEX);
+      Serial.write(' ');
+      Serial.print(addr[a][i], HEX);
+    }
     devAddrNames[a] = address;
     Serial.println();
-      if (strcmp(address.c_str(), config.DALLAS) == 0) {
-        sysvar.dallas_maitre = a;
-        logging.Set_log_init("MAIN " );
-      }
+    if (strcmp(address.c_str(), config.DALLAS) == 0) {
+      sysvar.dallas_maitre = a;
+      logging.Set_log_init("MAIN " );
+    }
 
-// détection de la 1ere présence d'une dallas 
-      if (strcmp("none", config.DALLAS) == 0 || strcmp("null", config.DALLAS) == 0 ) {
-        sysvar.dallas_maitre = a;
-        logging.Set_log_init("Default MAIN " );
-        // sauvegarde de l'adresse de la sonde maitre
-        strcpy(config.DALLAS, address.c_str());
-        config.saveConfiguration();
-      }
+    // détection de la 1ere présence d'une dallas
+    if (strcmp("none", config.DALLAS) == 0 || strcmp("null", config.DALLAS) == 0 ) {
+      sysvar.dallas_maitre = a;
+      logging.Set_log_init("Default MAIN " );
+      // sauvegarde de l'adresse de la sonde maitre
+      strcpy(config.DALLAS, address.c_str());
+      config.saveConfiguration();
+    }
 
     logging.Set_log_init(Dallas_sensor);
-    logging.Set_log_init(String(a).c_str()); 
+    logging.Set_log_init(String(a).c_str());
     logging.Set_log_init(found_Address);
-    logging.Set_log_init(String(address).c_str()); 
+    logging.Set_log_init(String(address).c_str());
     logging.Set_log_init("\r\n");
-    present = 1 ; 
-    
+    present = 1;
+
     delay(250);
     ds.reset();
     ds.select(addr[a]);
 
     ds.write(0x44, 1);        // start conversion, with parasite power on at the end
-  
+
     delay(1000);     // maybe 750ms is enough, maybe not
-  // we might do a ds.depower() here, but the reset will take care of it.
-  
+    // we might do a ds.depower() here, but the reset will take care of it.
+
     present = ds.reset();    ///  byte 0 > 1 si present
     delay(1000);
 
-    ds.select(addr[a]);    
+    ds.select(addr[a]);
     ds.write(0xBE);         // Read Scratchpad
-  
+
 
   }
-   return true;
-  }
+  return true;
+}
 
 
 String stringBool(bool myBool) {
@@ -1145,12 +1136,12 @@ String stringBool(bool myBool) {
 
 
 void tests () {
-///test de debug
+/// test de debug
 #ifdef ROBOTDYN
   USE_SERIAL.println("--- Toggle dimmer example start ---");
   dimmer.setState(ON); // state: dimmer1.setState(ON/OFF);
   dimmer.setState(ON);
-  dimmer3.setState(ON); 
+  dimmer3.setState(ON);
   dimmer2.setState(ON);
   dimmer2.setPower(100);
   dimmer3.setPower(100);
@@ -1161,7 +1152,6 @@ void tests () {
   dimmer3.setPower(0);
   delay(5000);
   USE_SERIAL.println("--- Toggle dimmer example end ---");
-
-#endif  
+#endif
 }
 

--- a/src/tasks/cooler.h
+++ b/src/tasks/cooler.h
@@ -1,4 +1,4 @@
-#ifndef TASK_COOLER 
+#ifndef TASK_COOLER
 #define TASK_COOLER
 
 #include "Arduino.h"
@@ -9,46 +9,47 @@ extern Mqtt mqtt_config;
 extern String logs;
 extern bool AP; // mode point d'accès
 extern HA device_cooler;
-//extern byte security;
+// extern byte security;
 extern Programme programme;
 
 unsigned long lastCoolerOffTime = 0; // NOSONAR
 constexpr const unsigned long cooldownDuration = 60 * 1000; // 1 minute en millisecondes
 
 void cooler() {
-                      
-    bool cooler_change = sysvar.cooler ;
 
-    /// controle du cooler 
-    if (config.dimmer_on_off == 1){
-        if ( ( sysvar.puissance > config.minpow && sysvar.celsius[sysvar.dallas_maitre]< config.maxtemp && sysvar.security == 0 ) || ( programme.run == true )) {
-            sysvar.cooler = true;
-        } else {
-            sysvar.cooler = false;
-        }
-    } 
-    else {
-        sysvar.cooler = false;
+  bool cooler_change = sysvar.cooler;
+
+  /// controle du cooler
+  if (config.dimmer_on_off == 1) {
+    if ( ( sysvar.puissance > config.minpow && sysvar.celsius[sysvar.dallas_maitre]< config.maxtemp &&
+           sysvar.security == 0 ) || ( programme.run == true )) {
+      sysvar.cooler = true;
+    } else {
+      sysvar.cooler = false;
     }
+  }
+  else {
+    sysvar.cooler = false;
+  }
 
-    if ( cooler_change != sysvar.cooler ) {
-        if ( sysvar.cooler == 1 ) {
-        digitalWrite(COOLER, HIGH);
-        // envoie mqtt
-        if ( config.HA ) {  device_cooler.send(stringBool(true));  }
-        } else {
-        lastCoolerOffTime = millis(); // on enregistre le temps d'arret pour le cooldown
-        }
-
+  if ( cooler_change != sysvar.cooler ) {
+    if ( sysvar.cooler == 1 ) {
+      digitalWrite(COOLER, HIGH);
+      // envoie mqtt
+      if ( config.HA ) {  device_cooler.send(stringBool(true));  }
+    } else {
+      lastCoolerOffTime = millis();   // on enregistre le temps d'arret pour le cooldown
     }
+  }
 
-    if (sysvar.cooler == 0 && millis() - lastCoolerOffTime >= cooldownDuration && digitalRead(COOLER) == HIGH && programme.run == false) {
-        digitalWrite(COOLER, LOW); // Éteindre le ventilateur après X secondes (cooldownDuration)
-    
-        if ( config.HA ) {  device_cooler.send(stringBool(false));  }
-        }
+  if (sysvar.cooler == 0 && millis() - lastCoolerOffTime >= cooldownDuration && digitalRead(COOLER) == HIGH &&
+      programme.run == false) {
+    digitalWrite(COOLER, LOW);     // Éteindre le ventilateur après X secondes (cooldownDuration)
 
- // pas besoin de tempo pour l'arret, vu que c'est toute les 15 secondes la task 
+    if ( config.HA ) {  device_cooler.send(stringBool(false));  }
+  }
+
+  // pas besoin de tempo pour l'arret, vu que c'est toute les 15 secondes la task
 }
 
 #endif

--- a/src/tasks/dallas.h
+++ b/src/tasks/dallas.h
@@ -2,19 +2,19 @@
 #define TASK_DALLAS
 
 #ifdef STANDALONE
-//#include <Pinger.h>
-//Pinger pinger;
+// #include <Pinger.h>
+// Pinger pinger;
 #endif
 
 extern PubSubClient client;
 extern DallasTemperature sensors;
 extern bool AP; // mode point d'accès
 extern Mqtt mqtt_config; // configuration mqtt
-extern byte present; // capteur dallas présent ou non 
+extern byte present; // capteur dallas présent ou non
 extern String logs; // logs
-//extern byte security; // sécurité
+// extern byte security; // sécurité
 extern DeviceAddress addr[MAX_DALLAS];  // NOSONAR
-extern float previous_celsius[MAX_DALLAS]; // température précédente //NOSONAR
+extern float previous_celsius[MAX_DALLAS]; // température précédente // NOSONAR
 extern IPAddress gatewayIP;
 extern HA devicetemp[MAX_DALLAS]; // NOSONAR
 extern int deviceCount; // nombre de sonde(s) dallas détectée(s)
@@ -28,27 +28,29 @@ bool dallaspresent ();
 int timer_dallas = 500; // timer pour la dallas
 
 /// @brief / task executé toute les n secondes pour publier la température ( voir déclaration task dans main )
-void mqttdallas() { 
-        if ( present == 1 ) {
-      sensors.requestTemperatures();
-    // delai plu utile vu que demande de relevé fait il y a ~15 sec 
+void mqttdallas() {
+  if ( present == 1 ) {
+    sensors.requestTemperatures();
+    // delai plu utile vu que demande de relevé fait il y a ~15 sec
     delay(timer_dallas);
     for (int a = 0; a < deviceCount; a++) {
       sysvar.celsius[a]=CheckTemperature("temp_" + devAddrNames[a],addr[a]);
-      //gestion des erreurs DS18B20
-      if ( (sysvar.celsius[a] == DEVICE_DISCONNECTED_C) || (sysvar.celsius[a] == -255.00) || (sysvar.celsius[a] > 200.00) ) {
+      // gestion des erreurs DS18B20
+      if ( (sysvar.celsius[a] == DEVICE_DISCONNECTED_C) || (sysvar.celsius[a] == -255.00) ||
+           (sysvar.celsius[a] > 200.00) ) {
         sysvar.celsius[a]=previous_celsius[a];
-        dallas_error[a] ++; // incrémente le compteur d'erreur
+        dallas_error[a]++;  // incrémente le compteur d'erreur
         logging.Set_log_init("Dallas " + String(a) + " : échec "+ String(dallas_error[a]) + "\r\n",true);
-        if ( timer_dallas < 1500 )  { timer_dallas = timer_dallas + 100;  } // on augmente le timer pour la prochaine lecture 
-          }
-          else { 
+        if ( timer_dallas < 1500 )  { timer_dallas = timer_dallas + 100;  } // on augmente le timer pour la prochaine lecture
+      }
+      else {
         sysvar.celsius[a] = (roundf(sysvar.celsius[a] * 10) / 10 ) + 0.1; // pour les valeurs min
         dallas_error[a] = 0; // remise à zéro du compteur d'erreur
-      }   
+      }
     }
     if (!AP && mqtt_config.mqtt) {
-      if ( sysvar.celsius[sysvar.dallas_maitre] != previous_celsius[sysvar.dallas_maitre]  || sysvar.celsius[sysvar.dallas_maitre] != 0.99) {
+      if ( sysvar.celsius[sysvar.dallas_maitre] != previous_celsius[sysvar.dallas_maitre]  ||
+           sysvar.celsius[sysvar.dallas_maitre] != 0.99) {
         Mqtt_send_DOMOTICZ(String(config.IDXTemp), String(sysvar.celsius[sysvar.dallas_maitre]),"Temperature");
       }
 
@@ -61,84 +63,77 @@ void mqttdallas() {
         device_temp_master.HA_discovery();
         device_dimmer_maxtemp.HA_discovery();
         device_dimmer_alarm_temp.send(stringBoolMQTT(sysvar.security));
-        device_dimmer_maxtemp.send(String(config.maxtemp)); 
+        device_dimmer_maxtemp.send(String(config.maxtemp));
         device_dimmer_alarm_temp_clear.HA_discovery();
       }
 
-/// uniformisation des valeurs de température ( for en valeur I pour retrouver plus facilement)
-      dallas_wait_log ++;
+      // uniformisation des valeurs de température ( for en valeur I pour retrouver plus facilement)
+      dallas_wait_log++;
       for (int i = 0; i < deviceCount; i++) {
-        
+
         if ( sysvar.celsius[i] != previous_celsius[i] || sysvar.celsius[i] != 0.99) {
           device_temp[i].send(String(sysvar.celsius[i]));
           previous_celsius[i]=sysvar.celsius[i];
-          
           if ( dallas_wait_log > 5 ) { /// limitation de l'affichage des logs de température
             logging.Set_log_init("Dallas " + String(i) + " : " + String(sysvar.celsius[i]) + "\r\n",false);
           }
-          
         }
       }
-      if ( dallas_wait_log > 5 ) { dallas_wait_log = 0 ; } 
-      
+      if ( dallas_wait_log > 5 ) { dallas_wait_log = 0; }
       device_temp_master.send(String(sysvar.celsius[sysvar.dallas_maitre]));
-    }          
-    /// on demande la température suivante pour le prochain cycle
-    
-         } 
-    //// détection sécurité température
-  if  ( sysvar.celsius[sysvar.dallas_maitre] >= config.maxtemp ) {
-        // coupure du dimmer
-        DEBUG_PRINTLN("détection sécurité température");
-
-      
-        unified_dimmer.dimmer_off();
-        
-      
-      if ( strcmp(config.child,"") != 0 && strcmp(config.mode,"off") != 0){
-            // si ça n'est pas le cas, on ne fait rien ... c'est bien parfois de ne rien faire 
-      }
-      else {
-        sysvar.puissance=0;      
-        unified_dimmer.dimmer_off();
-      }
-
-        
-      if ( mqtt_config.mqtt ) {
-        Mqtt_send_DOMOTICZ(String(config.IDX), "0");
-      }
-      if ( config.HA ) { 
-        device_dimmer.send("0"); 
-        device_dimmer_power.send("0");
-
-      }
     }
-  
+    // on demande la température suivante pour le prochain cycle
+
+  }
+  // détection sécurité température
+  if  ( sysvar.celsius[sysvar.dallas_maitre] >= config.maxtemp ) {
+    // coupure du dimmer
+    DEBUG_PRINTLN("détection sécurité température");
+
+    unified_dimmer.dimmer_off();
+
+    if ( strcmp(config.child,"") != 0 && strcmp(config.mode,"off") != 0) {
+      // si ça n'est pas le cas, on ne fait rien ... c'est bien parfois de ne rien faire
+    }
+    else {
+      sysvar.puissance=0;
+      unified_dimmer.dimmer_off();
+    }
+
+    if ( mqtt_config.mqtt ) {
+      Mqtt_send_DOMOTICZ(String(config.IDX), "0");
+    }
+    if ( config.HA ) {
+      device_dimmer.send("0");
+      device_dimmer_power.send("0");
+
+    }
+  }
+
   previous_celsius[sysvar.dallas_maitre]=sysvar.celsius[sysvar.dallas_maitre];
 
   // si trop d'erreur dallas, on remonte en mqtt
   for (int a = 0; a < deviceCount; a++) {
     if ( dallas_error[a] > 5 ) {
-    DEBUG_PRINTLN("détection perte sonde dallas");
+      DEBUG_PRINTLN("détection perte sonde dallas");
 
-    Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String(Dallas_lost),"Dallas perdue");
-    logging.Set_log_init(String(Dallas_lost) + "\r\n",true);
+      Mqtt_send_DOMOTICZ(String(config.IDXAlarme), String(Dallas_lost),"Dallas perdue");
+      logging.Set_log_init(String(Dallas_lost) + "\r\n",true);
       dallas_error[a] = 0; // remise à zéro du compteur d'erreur
-    ///mise en sécurité
-      sysvar.celsius[a] = 99.9; 
+      /// mise en sécurité
+      sysvar.celsius[a] = 99.9;
 
       previous_celsius[a]=sysvar.celsius[a];
       if (a == sysvar.dallas_maitre) {
-       String temp_topic = "Xlyric/" + String(config.say_my_name) + "/dallas" ;
+        String temp_topic = "Xlyric/" + String(config.say_my_name) + "/dallas";
 
-       String message = String(logging.loguptime()) + "Dallas maitre perdue";
-       client.publish((temp_topic+"dallas").c_str(), String(message).c_str(),true);
+        String message = String(logging.loguptime()) + "Dallas maitre perdue";
+        client.publish((temp_topic+"dallas").c_str(), String(message).c_str(),true);
 
-    unified_dimmer.dimmer_off();  /// mise en sécurité de l'ensemble
-
-      }
+        unified_dimmer.dimmer_off(); /// mise en sécurité de l'ensemble
       }
     }
+  }
 
 
 #ifdef qsdfsqdsfqs
@@ -146,37 +141,34 @@ void mqttdallas() {
     gw_error = 0; // remise à zéro du compteur d'erreur
   }
   else {
-    gw_error ++; // incrémente le compteur d'erreur
+    gw_error++;  // incrémente le compteur d'erreur
   }
 
-/// si GW perdu, reboot de l'ESP après 2 minutes
+  /// si GW perdu, reboot de l'ESP après 2 minutes
   if ( gw_error > 8 ) {
     DEBUG_PRINTLN("détection perte gateway");
-      config.restart = true;
+    config.restart = true;
   }
 #endif
 
 }
- 
-    //***********************************
-    //************* récupération d'une température du 18b20
-    //***********************************
+
+//***********************************
+//************* récupération d'une température du 18b20
+//***********************************
 
 float CheckTemperature(String label, byte deviceAddress[12]){ // NOSONAR
-
-
   float tempC = sensors.getTempC(deviceAddress);
-
   if ( (tempC == DEVICE_DISCONNECTED_C) || (tempC == -255.00) ) {
     delay(500);
-    //// cas d'une sonde trop longue à préparer les valeurs 
-     /// attente de 187ms ( temps de réponse de la sonde )
+    // cas d'une sonde trop longue à préparer les valeurs
+    // attente de 187ms ( temps de réponse de la sonde )
     tempC = sensors.getTempC(deviceAddress);
-  }  
-  return tempC; 
+  }
+  return tempC;
 }
 
-/// fonction pour relancer une détection de la dallas en cas de perte ou de non détection
+// fonction pour relancer une détection de la dallas en cas de perte ou de non détection
 void restart_dallas() {
   if (deviceCount == 0 ) {
     sensors.begin();
@@ -184,16 +176,14 @@ void restart_dallas() {
     deviceCount = sensors.getDeviceCount();
     if ( deviceCount > 0 )  {
       present = 1;
-      logging.Set_log_init(String(deviceCount)); 
+      logging.Set_log_init(String(deviceCount));
       logging.Set_log_init(" DALLAS detected\r\n");
       devices_init(); // initialisation des devices HA
-       
     }
 
     if (!dallaspresent()) {
-     delay(3000);
+      delay(3000);
     }
-
   }
 }
 

--- a/src/tasks/get_power.h
+++ b/src/tasks/get_power.h
@@ -13,31 +13,27 @@ extern HTTPClient http;
 
 
 void get_dimmer_child_power (){
-    /// récupération de la puissance du dimmer enfant en http
+  // récupération de la puissance du dimmer enfant en http
+  if (!strcmp(config.mode, "off") == 0) {
+    String baseurl;
+    baseurl = "/state";
+    http.begin(domotic_client, String(config.child),80,baseurl);
 
-     if (!strcmp(config.mode, "off") == 0) {
-        String baseurl; 
-        baseurl = "/state";
-        http.begin(domotic_client, String(config.child),80,baseurl);   
-        
-        int httpResponseCode = http.GET();
-        String dimmerstate = "0"; 
-        dimmerstate = http.getString();
-        http.end();
-        
-        if (httpResponseCode==200) {
-            JsonDocument doc;
-            deserializeJson(doc, dimmerstate);
-            sysvar.puissance_cumul = doc["Ptotal"];
-  
-            Serial.println(sysvar.puissance_cumul);
-        }
-        else {
-            sysvar.puissance_cumul = 0;
-        }
-     }
+    int httpResponseCode = http.GET();
+    String dimmerstate = "0";
+    dimmerstate = http.getString();
+    http.end();
 
+    if (httpResponseCode==200) {
+      JsonDocument doc;
+      deserializeJson(doc, dimmerstate);
+      sysvar.puissance_cumul = doc["Ptotal"];
+      Serial.println(sysvar.puissance_cumul);
+    }
+    else {
+      sysvar.puissance_cumul = 0;
+    }
+  }
 }
-
 
 #endif

--- a/src/tasks/ping.h
+++ b/src/tasks/ping.h
@@ -11,8 +11,8 @@
 #else
 // Web services
   #include <ESP8266WiFi.h>
-  //#include <ESPAsyncTCP.h>
-  #include <ESP8266HTTPClient.h> 
+// #include <ESPAsyncTCP.h>
+  #include <ESP8266HTTPClient.h>
 #endif
 
 extern System sysvar;
@@ -20,27 +20,25 @@ extern WiFiClient domotic_client;
 
 
 void ping() {
-    /// test du ping du site internet
-    
-        HTTPClient http;
-        http.begin(domotic_client, String(sysvar.pingurl),80, "/ping");
-        int httpCode = http.GET();
-        if (httpCode > 0) {
-            Serial.printf("[HTTP PING] GET... code: %d\n", httpCode);
-            if (httpCode == HTTP_CODE_OK) {
-                sysvar.ping = true;
-                sysvar.pingfail = 0;
-            }
-        } else {
-            Serial.printf("[HTTP PING] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
-            sysvar.pingfail ++;
-            if (sysvar.pingfail > 3 && sysvar.ping == true) {
-                Serial.print("[HTTP PING] connexion lost reboot ");
-                ESP.restart();
-            }
-        }
-        http.end();
-   
+  // test du ping du site internet
+  HTTPClient http;
+  http.begin(domotic_client, String(sysvar.pingurl),80, "/ping");
+  int httpCode = http.GET();
+  if (httpCode > 0) {
+    Serial.printf("[HTTP PING] GET... code: %d\n", httpCode);
+    if (httpCode == HTTP_CODE_OK) {
+      sysvar.ping = true;
+      sysvar.pingfail = 0;
+    }
+  } else {
+    Serial.printf("[HTTP PING] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
+    sysvar.pingfail++;
+    if (sysvar.pingfail > 3 && sysvar.ping == true) {
+      Serial.print("[HTTP PING] connexion lost reboot ");
+      ESP.restart();
+    }
+  }
+  http.end();
 }
 
 #endif

--- a/src/tasks/relais.h
+++ b/src/tasks/relais.h
@@ -1,52 +1,47 @@
 #ifndef TASK_RELAIS
 #define TASK_RELAIS
 
-#include "function/minuteur.h"    
+#include "function/minuteur.h"
 #include "Arduino.h"
 
-extern Programme programme_relay1; 
-extern Programme programme_relay2; 
+extern Programme programme_relay1;
+extern Programme programme_relay2;
 
 
 /// création de la task de controle pour les relais ( 15 s )
-
-
-
 void relais_controle() {
-    
+
     #ifdef RELAY1
-    /// activation du relai 1 si de seuil basse est remplie 
-    if (programme_relay1.start_seuil() && !programme_relay1.stop_seuil()) {
-        digitalWrite(RELAY1, HIGH);
-    }
+  /// activation du relai 1 si de seuil basse est remplie
+  if (programme_relay1.start_seuil() && !programme_relay1.stop_seuil()) {
+    digitalWrite(RELAY1, HIGH);
+  }
 
-    /// activation du relai 2 si de seuil basse est remplie
-    if (programme_relay2.start_seuil() && !programme_relay2.stop_seuil()) {
-        digitalWrite(RELAY2, HIGH);
-    }    
+  /// activation du relai 2 si de seuil basse est remplie
+  if (programme_relay2.start_seuil() && !programme_relay2.stop_seuil()) {
+    digitalWrite(RELAY2, HIGH);
+  }
 
-    /// déactivation du relai 1 si de seuil haute est remplie
-    if (programme_relay1.stop_seuil()) {
-        digitalWrite(RELAY1, LOW);
-    }
+  /// déactivation du relai 1 si de seuil haute est remplie
+  if (programme_relay1.stop_seuil()) {
+    digitalWrite(RELAY1, LOW);
+  }
 
-    /// déactivation du relai 2 si de seuil haute est remplie
-    if (programme_relay2.stop_seuil()) {
-        digitalWrite(RELAY2, LOW);
-    }
+  /// déactivation du relai 2 si de seuil haute est remplie
+  if (programme_relay2.stop_seuil()) {
+    digitalWrite(RELAY2, LOW);
+  }
 
-    /// désactivation Relai 1 si seuil temperature est atteint
-    if (programme_relay1.stop_seuil_temp()) {
-        digitalWrite(RELAY1, LOW);
-    }
+  /// désactivation Relai 1 si seuil temperature est atteint
+  if (programme_relay1.stop_seuil_temp()) {
+    digitalWrite(RELAY1, LOW);
+  }
 
-    /// désactivation relai 2 si seuil temperature est atteint
-    if (programme_relay2.stop_seuil_temp()) {
-        digitalWrite(RELAY2, LOW);
-    }
+  /// désactivation relai 2 si seuil temperature est atteint
+  if (programme_relay2.stop_seuil_temp()) {
+    digitalWrite(RELAY2, LOW);
+  }
     #endif
 }
-
-
 
 #endif


### PR DESCRIPTION
Comme discuté dans #60, je te propose une autre version de cette PR, rebasée sur les dernières modifications et faites en utilisant `uncrustify` pour le nettoyage du code C++, histoire d'être sûre de ne rien casser au passage. Pour la partie HTML/JS, c'est toujours fait via `prettier`. J'en ai profité pour uniformiser le fallback sur le JQuery de l'ESP et supprimer la duplication du chargement de deux versions de JQuery sur certaines pages.
