### PR TITLE
Ajout de la version nécessaire de la plateforme espressif8266

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,90 +13,95 @@
 framework = arduino
 board_build.filesystem = littlefs
 monitor_speed = 115200
-lib_deps = 
-    ;mathieucarbou/ESPAsyncWebServer@3.0.5
-	bblanchon/ArduinoJson@^7.1.0
+lib_deps =
+  ;mathieucarbou/ESPAsyncWebServer@3.0.5
+  bblanchon/ArduinoJson@^7.1.0
 
-	;marvinroger/AsyncMqttClient@^0.9.0 // provoque des conflits
-	knolleary/pubsubclient@^2.8.0 ; remplace AsyncMqttClient
-	
-    ;arduino-libraries/WiFi@^1.2.7
-	alanswx/ESPAsyncWiFiManager
-	paulstoffregen/OneWire
-	milesburton/DallasTemperature
-	https://github.com/xlyric/RBDDimmer
-	;https://github.com/xlyric/AsyncElegantOTA
-	https://github.com/ayushsharma82/ElegantOTA@^3.1.5
-	;./lib/ElegantOTAPro-3-1-3
-	https://github.com/YiannisBourkelis/Uptime-Library
-	arkhipenko/TaskScheduler@^3.7.0 
+  ;marvinroger/AsyncMqttClient@^0.9.0 // provoque des conflits
+  knolleary/pubsubclient@^2.8.0 ; remplace AsyncMqttClient
 
-	arduino-libraries/NTPClient@^3.2.1
-    paulstoffregen/Time
+  ;arduino-libraries/WiFi@^1.2.7
+  alanswx/ESPAsyncWiFiManager
+  paulstoffregen/OneWire
+  milesburton/DallasTemperature
+  https://github.com/xlyric/RBDDimmer
+  ;https://github.com/xlyric/AsyncElegantOTA
+  https://github.com/ayushsharma82/ElegantOTA@^3.1.5
+  ;./lib/ElegantOTAPro-3-1-3
+  https://github.com/YiannisBourkelis/Uptime-Library
+  arkhipenko/TaskScheduler@^3.7.0
+
+  arduino-libraries/NTPClient@^3.2.1
+  paulstoffregen/Time
 ;extra_scripts = post:prep_www_gzip.py
-	
+
 build_flags = -D LANG_FR
 ;LANG_EN
 ;LANG_UA
 
 
 [env:StandAlone]
-platform = espressif8266
-board = d1_mini
-upload_speed = 921600
-build_flags = 
-	${env.build_flags}
-	-D STANDALONE
-	-D ROBOTDYN
-
-	-D COMPILE_NAME=\"Alone\"
-	-g
-	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-lib_deps =
-  ${env.lib_deps}
-    https://github.com/bluemurder/esp8266-ping
-	;mathieucarbou/Async TCP@^3.0.2
-
-; compatible avec les SSR ZC 
-[env:SSR-Burst-Revisited]
-platform = espressif8266
+platform = espressif8266 @ ~4.2.1
 board = d1_mini
 upload_speed = 921600
 build_flags =
-	${env.build_flags} 
-	-D SSR
-	-D SSR_ZC
-	-D COMPILE_NAME=\"SSR-ZC\"
-	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+  ${env.build_flags}
+  -D STANDALONE
+  -D ROBOTDYN
+
+  -D COMPILE_NAME=\"Alone\"
+  -g
+  -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+lib_deps =
+  ${env.lib_deps}
+  https://github.com/bluemurder/esp8266-ping
+  ;mathieucarbou/Async TCP@^3.0.2
+
+; compatible avec les SSR ZC
+[env:SSR-Burst-Revisited]
+platform = espressif8266 @ ~4.2.1
+board = d1_mini
+upload_speed = 921600
+; Upload via USB
+#upload_port = /dev/ttyUSB0
+; Upload via OTA
+#upload_port = 192.168.8.205
+#upload_protocol = espota
+build_flags =
+  ${env.build_flags}
+  -D SSR
+  -D SSR_ZC
+  -D COMPILE_NAME=\"SSR-ZC\"
+  -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 lib_deps =
   ${env.lib_deps}
   ;mathieucarbou/Async TCP@^3.0.2
 
-;deprecated ESP8266 
+;deprecated ESP8266
 
 [env:POWERSUPPLY2022]
-platform = espressif8266
+platform = espressif8266 @ ~4.2.1
 board = d1_mini
 upload_speed = 115200
-build_flags = 
-	-D POWERSUPPLY2022
-	-D ROBOTDYN
-	-D COMPILE_NAME=\"PowerSupply2022\"
-	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+build_flags =
+  -D POWERSUPPLY2022
+  -D ROBOTDYN
+  -D COMPILE_NAME=\"PowerSupply2022\"
+  -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 lib_deps =
   ${env.lib_deps}
   ;mathieucarbou/Async TCP@^3.0.2
 
 [env:PowerSupplyACdimmer]
-platform = espressif8266
+platform = espressif8266 @ ~4.2.1
 board = d1_mini
 upload_speed = 921600
-build_flags = 
-	${env.build_flags}
-	-D POWERSUPPLY
-	-D ROBOTDYN
-	-D COMPILE_NAME=\"PowerSupply2023\"
-	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+build_flags =
+  ${env.build_flags}
+  -D POWERSUPPLY
+  -D ROBOTDYN
+  -D COMPILE_NAME=\"PowerSupply2023\"
+  -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 lib_deps =
   ${env.lib_deps}
   ;mathieucarbou/Async TCP@^3.0.2
@@ -108,28 +113,28 @@ board = esp32dev
 board_build.filesystem = spiffs
 upload_speed = 921600
 monitor_filters = esp32_exception_decoder, log2file
-build_flags = 
-	${env.build_flags}
-	-D ESP32
-	-D ROBOTDYN
-	-D STANDALONE
-	-D COMPILE_NAME=\"esp32dev\"
-	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+build_flags =
+  ${env.build_flags}
+  -D ESP32
+  -D ROBOTDYN
+  -D STANDALONE
+  -D COMPILE_NAME=\"esp32dev\"
+  -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 
   -DCORE_DEBUG_LEVEL=0
   -DUSER_SETUP_LOADED=25
   -DST7789_DRIVER
-  -DTFT_SDA_READ   
+  -DTFT_SDA_READ
   -DTFT_WIDTH=135
   -DTFT_HEIGHT=240
-  -DCGRAM_OFFSET      
+  -DCGRAM_OFFSET
   -DTFT_MOSI=19
   -DTFT_SCLK=18
   -DTFT_CS=5
   -DTFT_DC=16
   -DTFT_RST=23
-  -DTFT_BL=4  
-  -DTFT_BACKLIGHT_ON=HIGH  
+  -DTFT_BL=4
+  -DTFT_BACKLIGHT_ON=HIGH
   -DLOAD_GLCD
   -DLOAD_FONT2
   -DLOAD_FONT4
@@ -138,7 +143,7 @@ build_flags =
   -DLOAD_FONT8
   -DLOAD_GFXFF
   -DSMOOTH_FONT
-  -DSPI_FREQUENCY=40000000   
+  -DSPI_FREQUENCY=40000000
   -DSPI_READ_FREQUENCY=6000000
   -DCONFIG_COMPILER_STACK_CHECK_MODE_STRONG
 lib_deps =
@@ -146,42 +151,42 @@ lib_deps =
 
 
 ;[env:esp32dev]
-;platform = espressif32 @~6.1.0 
+;platform = espressif32 @~6.1.0
 ;board = esp32doit-devkit-v1
 ;board_build.filesystem = spiffs
 ;upload_speed = 921600
-;build_flags = 
-	;-D ESP32
-	;-D ROBOTDYN
-	;-D COMPILE_NAME=\"esp32dev\"
+;build_flags =
+  ;-D ESP32
+  ;-D ROBOTDYN
+  ;-D COMPILE_NAME=\"esp32dev\"
 ;lib_deps =
 ;  ${env.lib_deps}
-;    esphome/AsyncTCP-esphome@^2.0.0
+;  esphome/AsyncTCP-esphome@^2.0.0
 
 ;[env:esp32eth]
-;platform = espressif32 @~6.1.0 
+;platform = espressif32 @~6.1.0
 ;board = esp-wrover-kit
 ;board_build.filesystem = spiffs
 ;upload_speed = 115200
-;build_flags = 
-	;-D ESP32ETH
-	;-D ROBOTDYN
-	;-D COMPILE_NAME=\"esp32eth\"
+;build_flags =
+  ;-D ESP32ETH
+  ;-D ROBOTDYN
+  ;-D COMPILE_NAME=\"esp32eth\"
 ;lib_deps =
 ;  ${env.lib_deps}
-;    esphome/AsyncTCP-esphome@^2.0.0
+;  esphome/AsyncTCP-esphome@^2.0.0
 
 ;[env:esp32_wemos]
-;platform = espressif32 @~6.1.0 
+;platform = espressif32 @~6.1.0
 ;board = wemos_d1_mini32
 ;board_build.filesystem = spiffs
 ;upload_speed = 921600
 ;board_build.mcu = esp32
 ;board_build.f_cpu = 240000000L
-;build_flags = 
-	;-D ESP32
-	;-D ROBOTDYN
-	;-D COMPILE_NAME=\"Wemos_esp32\"
+;build_flags =
+  ;-D ESP32
+  ;-D ROBOTDYN
+  ;-D COMPILE_NAME=\"Wemos_esp32\"
 ;lib_deps =
 ;  ${env.lib_deps}
-;    esphome/AsyncTCP-esphome@^2.0.0
+;  esphome/AsyncTCP-esphome@^2.0.0


### PR DESCRIPTION
Comme discuté dans la PR #63, j'ai réglé mon problème de construction du firmware en mettant à jour la plateforme `espressif8266` dont aucune version minimale n'était spécifiée dans le fichier `platformio.ini`. Cette PR précise une version minimale à celle d'aujourd'hui (`4.2.1`). J'ai nettoyer au passage les indentations dans le fichier `platformio.ini`.