### PR TITLE
Constuction & publication des nouvelles versions via les actions Github

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,76 @@
+name: Build all supported platforms's firmware & filesystem and publish new release
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+            ~/.venv
+          key: ${{ runner.os }}-pio
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends lsb-release git python3-pip python3-venv curl gzip
+          python3 -m venv ~/.venv
+      - name: Install PlatformIO Core
+        run: ~/.venv/bin/python -m pip install platformio
+      - name: Build firmware for all supported platforms
+        run: ~/.venv/bin/pio run
+      - name: Generate filesystem content
+        run: |
+          source ~/.venv/bin/activate
+          ./data-templates/generate-data.sh
+      - name: Build filesystem for all supported platforms
+        run: ~/.venv/bin/pio run -t buildfs
+      - name: Compute version name
+        id: version
+        uses: proudust/gh-describe@v2.1.0
+      - name: Prepare distribution files
+        run: |
+          mkdir dist
+          for file in .pio/build/*/*.bin; do
+            platform="$( basename "$( dirname "$file" )" )"
+            filename="${platform}_${{steps.version.outputs.describe}}_$( basename "$file" ).gz"
+            gzip --stdout "$file" > "dist/$filename"
+          done
+      - name: Upload built files
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: dist
+          path: |
+            dist/*.bin.gz
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+    needs: build
+    steps:
+      - name: "Download built files"
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: dist
+      - name: Generate changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5.0.0
+        with:
+          mode: "COMMIT"
+      - name: Create release
+        uses: softprops/action-gh-release@v2.0.9
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          tag_name: ${{ steps.changelog.outputs.toTag }}
+          name: ${{ steps.changelog.outputs.toTag }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          make_latest: "true"
+          files: |
+            *.bin.gz
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/data-templates/generate-data.sh
+++ b/data-templates/generate-data.sh
@@ -162,4 +162,4 @@ echo "done."
 python -m pip install mako
 python "$SRC_DIR/generate-html-files.py"
 
-read -p "Press [Enter] to exit."
+[[ -n "$GITHUB_RUN_ID" ]] || read -p "Press [Enter] to exit."


### PR DESCRIPTION
Salut,

Comme discuté, j'ai écrit un workflow pour construire et publier des nouvelles versions via les actions Github.

* Pour la construction, elle est lancée à chaque _push_ (même sans tag) et elle construit les firmwares et les filesystems de toutes les plateformes supportées qui sont ensuite compressés (_gzip_) puis déposé en tant qu’artefact de l'action ([exemple] (https://github.com/brenard/PV-discharge-Dimmer-AC-Dimmer-KIT-Robotdyn/actions/runs/11689308568), les artefacts sont en bas de la page). Notes : 
  * le script `data-templates/generate-data.sh` est lancé également à chaque, rendant la conservation facultative du dossier `data` dans les sources. On pourrait donc le supprimer et l'ajouter dans le fichier `.gitignore` si on veut.
  * les artefacts restent disponibles pendant 90 jours et sont automatiquement supprimés ensuite.

* En cas d'ajout d'un tag, une release est créée sur Github ([exemple](https://github.com/brenard/PV-discharge-Dimmer-AC-Dimmer-KIT-Robotdyn/releases/tag/2024.11.1)):
  * Le nom de la release est le nom du tag
  * un changelog est généré à partir des messages de commits depuis le tag précédent
  * les firmwares et les filesystems sont déposés comme fichiers attachés à la release

__Important : __ Si ce fonctionnement te convient, il faudra penser à créer un premier tag sur le commit correspondant à ta dernière version publiée, afin que le changelog de la prochaine version soit correctement constitué.