### PR TITLE
Augmentation du timeout de détection des sondes dallas à 4s

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -5,6 +5,7 @@
 #define FS_RELEASE "20241105" // date de la release
 
 #define TEMPERATURE_PRECISION 10
+#define DALALS_TIMEOUT 4000
 // configuration for Standalone boards ( personnalisation )
 #ifdef  STANDALONE
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -578,7 +578,7 @@ void setup() {
 
   if (deviceCount == 0 ) { // si toujours pas trouvé
     sensors.begin(); // réinit du bus one wire
-    delay(1500);
+    delay(DALALS_TIMEOUT);
     deviceCount = sensors.getDeviceCount();
   }
 

--- a/src/tasks/dallas.h
+++ b/src/tasks/dallas.h
@@ -41,7 +41,7 @@ void mqttdallas() {
         sysvar.celsius[a]=previous_celsius[a];
         dallas_error[a]++;  // incrémente le compteur d'erreur
         logging.Set_log_init("Dallas " + String(a) + " : échec "+ String(dallas_error[a]) + "\r\n",true);
-        if ( timer_dallas < 1500 )  { timer_dallas = timer_dallas + 100;  } // on augmente le timer pour la prochaine lecture
+        if ( timer_dallas < DALALS_TIMEOUT )  { timer_dallas = timer_dallas + 100;  } // on augmente le timer pour la prochaine lecture
       }
       else {
         sysvar.celsius[a] = (roundf(sysvar.celsius[a] * 10) / 10 ) + 0.1; // pour les valeurs min
@@ -172,7 +172,7 @@ float CheckTemperature(String label, byte deviceAddress[12]){ // NOSONAR
 void restart_dallas() {
   if (deviceCount == 0 ) {
     sensors.begin();
-    delay(2000);
+    delay(DALALS_TIMEOUT);
     deviceCount = sensors.getDeviceCount();
     if ( deviceCount > 0 )  {
       present = 1;


### PR DESCRIPTION
Comme discuté dans #56, l'augmentation du timeout de détection des sondes dallas à régler mes soucis à cause de mes sondes un peu lente à la détente. Vu que le timeout est progressivement augmenté par pas de 100ms, ça ne devrait pas gêner les sondes "rapides" tout en permettant aux sondes plus lentes d'être détectées.